### PR TITLE
Devops 620 fix redis parse while checking

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # The following are targers that do not exist in the filesystem as real files and should be always executed by make
 .PHONY: default build deps-development docker-build shell run image unit-test test generate go-generate get-deps update-deps
-VERSION := 0.1.1
+VERSION := 0.1.2
 
 # Name of this service/application
 SERVICE_NAME := redis-operator

--- a/pkg/redis/client.go
+++ b/pkg/redis/client.go
@@ -76,7 +76,7 @@ func (c *client) ResetSentinel(ip string) error {
 		DB:       0,
 	}
 	rClient := rediscli.NewClient(options)
-	cmd := rediscli.NewStringCmd("SENTINEL", "reset", "*")
+	cmd := rediscli.NewIntCmd("SENTINEL", "reset", "*")
 	rClient.Process(cmd)
 	rClient.Close()
 	_, err := cmd.Result()


### PR DESCRIPTION
This fixes the following error:
```
time="2017-12-15T11:52:11Z" level=error msg="RedisFailover rfexample in namespace example has the following error: redis: can't parse string reply: \":1\"" namespace=example redisfailover=rfexample src="controller.go:78"
```

This was caused because a misusage of the go-redis library.

Thanks @slok for the help