### PR TITLE
Devops 649 fix waitforpod bug

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # The following are targers that do not exist in the filesystem as real files and should be always executed by make
 .PHONY: default build deps-development docker-build shell run image unit-test test generate go-generate get-deps update-deps
-VERSION := 0.1.3
+VERSION := 0.1.4
 
 # Name of this service/application
 SERVICE_NAME := redis-operator
@@ -88,6 +88,7 @@ publish:
 	@COMMIT_VERSION="$$(git rev-list -n 1 $(VERSION))"; \
 	docker tag $(REPOSITORY):"$$COMMIT_VERSION" $(REPOSITORY):$(VERSION)
 	docker push $(REPOSITORY):$(VERSION)
+	docker push $(REPOSITORY):latest
 
 release: tag image publish
 

--- a/pkg/failover/client.go
+++ b/pkg/failover/client.go
@@ -346,7 +346,9 @@ func (r *RedisFailoverKubeClient) CreateBootstrapPod(rf *RedisFailover) error {
 		return err
 	}
 
-	r.waitForPod(name, namespace, logger)
+	if err := r.waitForPod(name, namespace, logger); err != nil {
+		return err
+	}
 
 	return nil
 }
@@ -391,7 +393,9 @@ func (r *RedisFailoverKubeClient) CreateSentinelService(rf *RedisFailover) error
 		return err
 	}
 
-	r.waitForService(name, namespace, logger)
+	if err := r.waitForService(name, namespace, logger); err != nil {
+		return err
+	}
 
 	return nil
 }
@@ -521,7 +525,9 @@ func (r *RedisFailoverKubeClient) CreateSentinelDeployment(rf *RedisFailover) er
 		return err
 	}
 
-	r.waitForDeployment(name, namespace, spec.Sentinel.Replicas, logger)
+	if err := r.waitForDeployment(name, namespace, spec.Sentinel.Replicas, logger); err != nil {
+		return err
+	}
 
 	logger.Debug("Creating Sentinel PodDisruptionBudget...")
 	if err := r.createPodDisruptionBudget(rf, sentinelName, sentinelRoleName); err != nil {
@@ -659,7 +665,9 @@ func (r *RedisFailoverKubeClient) CreateRedisStatefulset(rf *RedisFailover) erro
 		return err
 	}
 
-	r.waitForStatefulset(name, namespace, spec.Redis.Replicas, logger)
+	if err := r.waitForStatefulset(name, namespace, spec.Redis.Replicas, logger); err != nil {
+		return err
+	}
 
 	logger.Debug("Creating Redis PodDisruptionBudget...")
 	if err := r.createPodDisruptionBudget(rf, redisName, redisRoleName); err != nil {
@@ -762,7 +770,9 @@ func (r *RedisFailoverKubeClient) UpdateSentinelDeployment(rf *RedisFailover) er
 		return err
 	}
 
-	r.waitForDeployment(name, namespace, replicas, logger)
+	if err := r.waitForDeployment(name, namespace, replicas, logger); err != nil {
+		return err
+	}
 
 	return nil
 }
@@ -799,7 +809,9 @@ func (r *RedisFailoverKubeClient) UpdateRedisStatefulset(rf *RedisFailover) erro
 		return err
 	}
 
-	r.waitForStatefulset(name, namespace, replicas, logger)
+	if err := r.waitForStatefulset(name, namespace, replicas, logger); err != nil {
+		return err
+	}
 
 	return nil
 }
@@ -815,7 +827,9 @@ func (r *RedisFailoverKubeClient) DeleteBootstrapPod(rf *RedisFailover) error {
 		return err
 	}
 
-	r.waitForPodDeletion(name, namespace, logger)
+	if err := r.waitForPodDeletion(name, namespace, logger); err != nil {
+		return err
+	}
 
 	return nil
 }
@@ -835,7 +849,9 @@ func (r *RedisFailoverKubeClient) DeleteRedisStatefulset(rf *RedisFailover) erro
 	}
 	logger.Debug("Redis PodDisruptionBudget deleted!")
 
-	r.waitForStatefulsetDeletion(name, namespace, logger)
+	if err := r.waitForStatefulsetDeletion(name, namespace, logger); err != nil {
+		return err
+	}
 
 	return nil
 }
@@ -855,7 +871,9 @@ func (r *RedisFailoverKubeClient) DeleteSentinelDeployment(rf *RedisFailover) er
 	}
 	logger.Debug("Sentinel PodDisruptionBudget deleted!")
 
-	r.waitForDeploymentDeletion(name, namespace, logger)
+	if err := r.waitForDeploymentDeletion(name, namespace, logger); err != nil {
+		return err
+	}
 
 	return nil
 }
@@ -870,7 +888,9 @@ func (r *RedisFailoverKubeClient) DeleteSentinelService(rf *RedisFailover) error
 		return err
 	}
 
-	r.waitForServiceDeletion(name, namespace, logger)
+	if err := r.waitForServiceDeletion(name, namespace, logger); err != nil {
+		return err
+	}
 
 	return nil
 }
@@ -885,7 +905,9 @@ func (r *RedisFailoverKubeClient) DeleteRedisService(rf *RedisFailover) error {
 		return err
 	}
 
-	r.waitForServiceDeletion(name, namespace, logger)
+	if err := r.waitForServiceDeletion(name, namespace, logger); err != nil {
+		return err
+	}
 
 	return nil
 }

--- a/pkg/failover/waiter.go
+++ b/pkg/failover/waiter.go
@@ -1,142 +1,192 @@
 package failover
 
 import (
+	"errors"
+
 	"github.com/spotahome/redis-operator/pkg/log"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/pkg/api/v1"
 )
 
-func (r *RedisFailoverKubeClient) waitForPod(name string, namespace string, logger log.Logger) {
+func (r *RedisFailoverKubeClient) waitForPod(name string, namespace string, logger log.Logger) error {
 	t := r.clock.NewTicker(loopInterval)
+	to := r.clock.After(waitTimeout)
 	defer t.Stop()
 
-	for range t.C {
-		logger.Debug("Waiting for pod to be ready")
-		pod, _ := r.Client.CoreV1().Pods(namespace).Get(name, metav1.GetOptions{})
-		for _, condition := range pod.Status.Conditions {
-			if condition.Type == "Ready" && condition.Status == v1.ConditionTrue {
-				return
+	for {
+		select {
+		case <-t.C:
+			logger.Debug("Waiting for pod to be ready")
+			pod, _ := r.Client.CoreV1().Pods(namespace).Get(name, metav1.GetOptions{})
+			for _, condition := range pod.Status.Conditions {
+				if condition.Type == "Ready" && condition.Status == v1.ConditionTrue {
+					return nil
+				}
 			}
+		case <-to:
+			return errors.New("Timeout waiting the condition")
 		}
 	}
 }
 
-func (r *RedisFailoverKubeClient) waitForService(name string, namespace string, logger log.Logger) {
+func (r *RedisFailoverKubeClient) waitForService(name string, namespace string, logger log.Logger) error {
 	t := r.clock.NewTicker(loopInterval)
+	to := r.clock.After(waitTimeout)
 	defer t.Stop()
 
-	for range t.C {
-		logger.Debug("Waiting for service to find bootstrap pod")
-		endpoints, _ := r.Client.CoreV1().Endpoints(namespace).Get(name, metav1.GetOptions{})
-		addresses := 0
-		for _, subset := range endpoints.Subsets {
-			addresses += len(subset.Addresses)
-		}
-		if addresses > 0 {
-			return
-		}
-	}
-}
-
-func (r *RedisFailoverKubeClient) waitForDeployment(name string, namespace string, replicas int32, logger log.Logger) {
-	t := r.clock.NewTicker(loopInterval)
-	defer t.Stop()
-
-	for range t.C {
-		logger.Debug("Waiting for Sentinel deployment to be fully operative")
-		deployment, _ := r.Client.AppsV1beta1().Deployments(namespace).Get(name, metav1.GetOptions{})
-		if deployment.Status.ReadyReplicas == replicas {
-			return
-		}
-	}
-}
-
-func (r *RedisFailoverKubeClient) waitForStatefulset(name string, namespace string, replicas int32, logger log.Logger) {
-	t := r.clock.NewTicker(loopInterval)
-	defer t.Stop()
-
-	for range t.C {
-		logger.Debug("Waiting for Redis statefulset to be fully operative")
-		statefulset, _ := r.Client.AppsV1beta1().StatefulSets(namespace).Get(name, metav1.GetOptions{})
-		if statefulset.Status.ReadyReplicas == replicas {
-			return
-		}
-	}
-}
-
-func (r *RedisFailoverKubeClient) waitForPodDeletion(name string, namespace string, logger log.Logger) {
-	t := r.clock.NewTicker(loopInterval)
-	defer t.Stop()
-
-	for range t.C {
-		logger.Debug("Waiting for pod to terminate")
-		podList, _ := r.Client.CoreV1().Pods(namespace).List(metav1.ListOptions{})
-		found := false
-		for _, pod := range podList.Items {
-			if pod.Name == name {
-				found = true
+	for {
+		select {
+		case <-t.C:
+			logger.Debug("Waiting for service to find bootstrap pod")
+			endpoints, _ := r.Client.CoreV1().Endpoints(namespace).Get(name, metav1.GetOptions{})
+			addresses := 0
+			for _, subset := range endpoints.Subsets {
+				addresses += len(subset.Addresses)
 			}
-		}
-		if !found {
-			return
+			if addresses > 0 {
+				return nil
+			}
+		case <-to:
+			return errors.New("Timeout waiting the condition")
 		}
 	}
 }
 
-func (r *RedisFailoverKubeClient) waitForStatefulsetDeletion(name string, namespace string, logger log.Logger) {
+func (r *RedisFailoverKubeClient) waitForDeployment(name string, namespace string, replicas int32, logger log.Logger) error {
 	t := r.clock.NewTicker(loopInterval)
+	to := r.clock.After(waitTimeout)
 	defer t.Stop()
 
-	for range t.C {
-		logger.Debug("Waiting for statefulset to terminate")
-		statefulsetList, _ := r.Client.AppsV1beta1().StatefulSets(namespace).List(metav1.ListOptions{})
-		found := false
-		for _, statefulset := range statefulsetList.Items {
-			if statefulset.Name == name {
-				found = true
+	for {
+		select {
+		case <-t.C:
+			logger.Debug("Waiting for Sentinel deployment to be fully operative")
+			deployment, _ := r.Client.AppsV1beta1().Deployments(namespace).Get(name, metav1.GetOptions{})
+			if deployment.Status.ReadyReplicas == replicas {
+				return nil
 			}
-		}
-		if !found {
-			return
+		case <-to:
+			return errors.New("Timeout waiting the condition")
 		}
 	}
 }
 
-func (r *RedisFailoverKubeClient) waitForDeploymentDeletion(name string, namespace string, logger log.Logger) {
+func (r *RedisFailoverKubeClient) waitForStatefulset(name string, namespace string, replicas int32, logger log.Logger) error {
 	t := r.clock.NewTicker(loopInterval)
+	to := r.clock.After(waitTimeout)
 	defer t.Stop()
 
-	for range t.C {
-		logger.Debug("Waiting for deployment to terminate")
-		deploymentList, _ := r.Client.Apps().Deployments(namespace).List(metav1.ListOptions{})
-		found := false
-		for _, deployment := range deploymentList.Items {
-			if deployment.Name == name {
-				found = true
+	for {
+		select {
+		case <-t.C:
+			logger.Debug("Waiting for Redis statefulset to be fully operative")
+			statefulset, _ := r.Client.AppsV1beta1().StatefulSets(namespace).Get(name, metav1.GetOptions{})
+			if statefulset.Status.ReadyReplicas == replicas {
+				return nil
 			}
-		}
-		if !found {
-			return
+		case <-to:
+			return errors.New("Timeout waiting the condition")
 		}
 	}
 }
 
-func (r *RedisFailoverKubeClient) waitForServiceDeletion(name string, namespace string, logger log.Logger) {
+func (r *RedisFailoverKubeClient) waitForPodDeletion(name string, namespace string, logger log.Logger) error {
 	t := r.clock.NewTicker(loopInterval)
+	to := r.clock.After(waitTimeout)
 	defer t.Stop()
 
-	for range t.C {
-		logger.Debug("Waiting for service to disappear")
-		serviceList, _ := r.Client.Core().Services(namespace).List(metav1.ListOptions{})
-		found := false
-		for _, service := range serviceList.Items {
-			if service.Name == name {
-				found = true
+	for {
+		select {
+		case <-t.C:
+			logger.Debug("Waiting for pod to terminate")
+			podList, _ := r.Client.CoreV1().Pods(namespace).List(metav1.ListOptions{})
+			found := false
+			for _, pod := range podList.Items {
+				if pod.Name == name {
+					found = true
+				}
 			}
+			if !found {
+				return nil
+			}
+		case <-to:
+			return errors.New("Timeout waiting the condition")
 		}
-		if !found {
-			return
+	}
+}
+
+func (r *RedisFailoverKubeClient) waitForStatefulsetDeletion(name string, namespace string, logger log.Logger) error {
+	t := r.clock.NewTicker(loopInterval)
+	to := r.clock.After(waitTimeout)
+	defer t.Stop()
+
+	for {
+		select {
+		case <-t.C:
+			logger.Debug("Waiting for statefulset to terminate")
+			statefulsetList, _ := r.Client.AppsV1beta1().StatefulSets(namespace).List(metav1.ListOptions{})
+			found := false
+			for _, statefulset := range statefulsetList.Items {
+				if statefulset.Name == name {
+					found = true
+				}
+			}
+			if !found {
+				return nil
+			}
+		case <-to:
+			return errors.New("Timeout waiting the condition")
+		}
+	}
+}
+
+func (r *RedisFailoverKubeClient) waitForDeploymentDeletion(name string, namespace string, logger log.Logger) error {
+	t := r.clock.NewTicker(loopInterval)
+	to := r.clock.After(waitTimeout)
+	defer t.Stop()
+
+	for {
+		select {
+		case <-t.C:
+			logger.Debug("Waiting for deployment to terminate")
+			deploymentList, _ := r.Client.Apps().Deployments(namespace).List(metav1.ListOptions{})
+			found := false
+			for _, deployment := range deploymentList.Items {
+				if deployment.Name == name {
+					found = true
+				}
+			}
+			if !found {
+				return nil
+			}
+		case <-to:
+			return errors.New("Timeout waiting the condition")
+		}
+	}
+}
+
+func (r *RedisFailoverKubeClient) waitForServiceDeletion(name string, namespace string, logger log.Logger) error {
+	t := r.clock.NewTicker(loopInterval)
+	to := r.clock.After(waitTimeout)
+	defer t.Stop()
+
+	for {
+		select {
+		case <-t.C:
+			logger.Debug("Waiting for service to disappear")
+			serviceList, _ := r.Client.Core().Services(namespace).List(metav1.ListOptions{})
+			found := false
+			for _, service := range serviceList.Items {
+				if service.Name == name {
+					found = true
+				}
+			}
+			if !found {
+				return nil
+			}
+		case <-to:
+			return errors.New("Timeout waiting the condition")
 		}
 	}
 }

--- a/pkg/failover/waiter.go
+++ b/pkg/failover/waiter.go
@@ -25,7 +25,7 @@ func (r *RedisFailoverKubeClient) waitForPod(name string, namespace string, logg
 				}
 			}
 		case <-to:
-			return errors.New("Timeout waiting the condition")
+			return errors.New("timeout waiting the condition")
 		}
 	}
 }
@@ -48,7 +48,7 @@ func (r *RedisFailoverKubeClient) waitForService(name string, namespace string, 
 				return nil
 			}
 		case <-to:
-			return errors.New("Timeout waiting the condition")
+			return errors.New("timeout waiting the condition")
 		}
 	}
 }
@@ -67,7 +67,7 @@ func (r *RedisFailoverKubeClient) waitForDeployment(name string, namespace strin
 				return nil
 			}
 		case <-to:
-			return errors.New("Timeout waiting the condition")
+			return errors.New("timeout waiting the condition")
 		}
 	}
 }
@@ -86,7 +86,7 @@ func (r *RedisFailoverKubeClient) waitForStatefulset(name string, namespace stri
 				return nil
 			}
 		case <-to:
-			return errors.New("Timeout waiting the condition")
+			return errors.New("timeout waiting the condition")
 		}
 	}
 }
@@ -111,7 +111,7 @@ func (r *RedisFailoverKubeClient) waitForPodDeletion(name string, namespace stri
 				return nil
 			}
 		case <-to:
-			return errors.New("Timeout waiting the condition")
+			return errors.New("timeout waiting the condition")
 		}
 	}
 }
@@ -136,7 +136,7 @@ func (r *RedisFailoverKubeClient) waitForStatefulsetDeletion(name string, namesp
 				return nil
 			}
 		case <-to:
-			return errors.New("Timeout waiting the condition")
+			return errors.New("timeout waiting the condition")
 		}
 	}
 }
@@ -161,7 +161,7 @@ func (r *RedisFailoverKubeClient) waitForDeploymentDeletion(name string, namespa
 				return nil
 			}
 		case <-to:
-			return errors.New("Timeout waiting the condition")
+			return errors.New("timeout waiting the condition")
 		}
 	}
 }
@@ -186,7 +186,7 @@ func (r *RedisFailoverKubeClient) waitForServiceDeletion(name string, namespace 
 				return nil
 			}
 		case <-to:
-			return errors.New("Timeout waiting the condition")
+			return errors.New("timeout waiting the condition")
 		}
 	}
 }


### PR DESCRIPTION
There were a bug introduced when a the waiter was created.

To create the resources, a name is generated:
* rfb-NAME
* rfr-NAME
* rfs-NAME

(bootstrap, redis, sentinel). When checking if the pod was created, the name passed was incorrect (was rf.Metadata.Name in stead of the generated one). This is now fixed.

Also, a timeout on waiters are added, so a failure is raised if more than 15 minutes wait.

Created a new version.