### PR TITLE
Devops 648 ensure schedule different nodes

### DIFF
--- a/pkg/failover/client.go
+++ b/pkg/failover/client.go
@@ -38,7 +38,6 @@ const (
 	sentinelRoleName    = "sentinel"
 	redisName           = "r"
 	redisRoleName       = "redis"
-	bootstrapRoleName   = "bootstrap"
 	appLabel            = "redis-failover"
 	hostnameTopologyKey = "kubernetes.io/hostname"
 )
@@ -271,7 +270,7 @@ func (r *RedisFailoverKubeClient) CreateBootstrapPod(rf *RedisFailover) error {
 	redisResources := getRedisResources(spec)
 	sentinelResources := getSentinelResources(spec)
 
-	labels := generateLabels(bootstrapRoleName, rf.Metadata.Name)
+	labels := generateLabels(sentinelRoleName, rf.Metadata.Name)
 
 	pod := &v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/failover/client.go
+++ b/pkg/failover/client.go
@@ -175,7 +175,7 @@ func (r *RedisFailoverKubeClient) GetBootstrapPod(rf *RedisFailover) (*v1.Pod, e
 	namespace := rf.Metadata.Namespace
 	pod, err := r.Client.Core().Pods(namespace).Get(name, metav1.GetOptions{})
 	if err != nil {
-		return nil, errors.New("Could not get pod")
+		return nil, errors.New("could not get pod")
 	}
 	return pod, nil
 }
@@ -186,7 +186,7 @@ func (r *RedisFailoverKubeClient) GetSentinelService(rf *RedisFailover) (*v1.Ser
 	namespace := rf.Metadata.Namespace
 	service, err := r.Client.Core().Services(namespace).Get(name, metav1.GetOptions{})
 	if err != nil {
-		return nil, errors.New("Could not get service")
+		return nil, errors.New("could not get service")
 	}
 	return service, nil
 }
@@ -197,7 +197,7 @@ func (r *RedisFailoverKubeClient) GetSentinelDeployment(rf *RedisFailover) (*v1b
 	namespace := rf.Metadata.Namespace
 	deployment, err := r.Client.AppsV1beta1().Deployments(namespace).Get(name, metav1.GetOptions{})
 	if err != nil {
-		return nil, errors.New("Could not get deployment")
+		return nil, errors.New("could not get deployment")
 	}
 	return deployment, nil
 }
@@ -208,7 +208,7 @@ func (r *RedisFailoverKubeClient) GetRedisService(rf *RedisFailover) (*v1.Servic
 	namespace := rf.Metadata.Namespace
 	service, err := r.Client.Core().Services(namespace).Get(name, metav1.GetOptions{})
 	if err != nil {
-		return nil, errors.New("Could not get service")
+		return nil, errors.New("could not get service")
 	}
 	return service, nil
 }
@@ -219,7 +219,7 @@ func (r *RedisFailoverKubeClient) GetRedisStatefulset(rf *RedisFailover) (*v1bet
 	namespace := rf.Metadata.Namespace
 	statefulset, err := r.Client.AppsV1beta1().StatefulSets(namespace).Get(name, metav1.GetOptions{})
 	if err != nil {
-		return nil, errors.New("Could not get statefulset")
+		return nil, errors.New("could not get statefulset")
 	}
 	return statefulset, nil
 }
@@ -233,7 +233,7 @@ func (r *RedisFailoverKubeClient) GetSentinelPodsIPs(rf *RedisFailover) ([]strin
 		return nil, err
 	}
 	if len(endpoints.Subsets) != 1 {
-		return nil, errors.New("The Sentinel Service has different endpoints than expected")
+		return nil, errors.New("the Sentinel Service has different endpoints than expected")
 	}
 	pods := []string{}
 	for _, e := range endpoints.Subsets[0].Addresses {

--- a/pkg/failover/client.go
+++ b/pkg/failover/client.go
@@ -271,7 +271,7 @@ func (r *RedisFailoverKubeClient) CreateBootstrapPod(rf *RedisFailover) error {
 	redisResources := getRedisResources(spec)
 	sentinelResources := getSentinelResources(spec)
 
-	labels := generateLabels(rf.Metadata.Name, bootstrapRoleName)
+	labels := generateLabels(bootstrapRoleName, rf.Metadata.Name)
 
 	pod := &v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
@@ -371,7 +371,7 @@ func (r *RedisFailoverKubeClient) CreateSentinelService(rf *RedisFailover) error
 
 	sentinelTargetPort := intstr.FromInt(26379)
 
-	labels := generateLabels(rf.Metadata.Name, sentinelRoleName)
+	labels := generateLabels(sentinelRoleName, rf.Metadata.Name)
 
 	sentinelSvc := &v1.Service{
 		ObjectMeta: metav1.ObjectMeta{
@@ -416,7 +416,7 @@ func (r *RedisFailoverKubeClient) CreateSentinelDeployment(rf *RedisFailover) er
 
 	resources := getSentinelResources(spec)
 
-	labels := generateLabels(rf.Metadata.Name, sentinelRoleName)
+	labels := generateLabels(sentinelRoleName, rf.Metadata.Name)
 
 	sentinelDeployment := &v1beta1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
@@ -562,7 +562,7 @@ func (r *RedisFailoverKubeClient) CreateRedisStatefulset(rf *RedisFailover) erro
 
 	resources := getRedisResources(spec)
 
-	labels := generateLabels(rf.Metadata.Name, redisRoleName)
+	labels := generateLabels(redisRoleName, rf.Metadata.Name)
 
 	redisStatefulset := &v1beta1.StatefulSet{
 		ObjectMeta: metav1.ObjectMeta{
@@ -706,7 +706,7 @@ func (r *RedisFailoverKubeClient) CreateRedisService(rf *RedisFailover) error {
 	name := r.GetRedisName(rf)
 	namespace := rf.Metadata.Namespace
 
-	labels := generateLabels(rf.Metadata.Name, redisRoleName)
+	labels := generateLabels(redisRoleName, rf.Metadata.Name)
 
 	srv := &v1.Service{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/failover/client.go
+++ b/pkg/failover/client.go
@@ -31,15 +31,16 @@ const (
 )
 
 const (
-	description       = "Manage a Redis Failover deployment"
-	baseName          = "rf"
-	bootstrapName     = "b"
-	sentinelName      = "s"
-	sentinelRoleName  = "sentinel"
-	redisName         = "r"
-	redisRoleName     = "redis"
-	bootstrapRoleName = "bootstrap"
-	appLabel          = "redis-failover"
+	description         = "Manage a Redis Failover deployment"
+	baseName            = "rf"
+	bootstrapName       = "b"
+	sentinelName        = "s"
+	sentinelRoleName    = "sentinel"
+	redisName           = "r"
+	redisRoleName       = "redis"
+	bootstrapRoleName   = "bootstrap"
+	appLabel            = "redis-failover"
+	hostnameTopologyKey = "kubernetes.io/hostname"
 )
 
 const (
@@ -433,6 +434,7 @@ func (r *RedisFailoverKubeClient) CreateSentinelDeployment(rf *RedisFailover) er
 						PodAntiAffinity: &v1.PodAntiAffinity{
 							RequiredDuringSchedulingIgnoredDuringExecution: []v1.PodAffinityTerm{
 								v1.PodAffinityTerm{
+									TopologyKey: hostnameTopologyKey,
 									LabelSelector: &metav1.LabelSelector{
 										MatchLabels: labels,
 									},
@@ -582,6 +584,7 @@ func (r *RedisFailoverKubeClient) CreateRedisStatefulset(rf *RedisFailover) erro
 						PodAntiAffinity: &v1.PodAntiAffinity{
 							RequiredDuringSchedulingIgnoredDuringExecution: []v1.PodAffinityTerm{
 								v1.PodAffinityTerm{
+									TopologyKey: hostnameTopologyKey,
 									LabelSelector: &metav1.LabelSelector{
 										MatchLabels: labels,
 									},


### PR DESCRIPTION
Add AntiAffinity to Redis and Sentinel nodes.

Having this, no multiple pods of the same RF will be deployed on the same node. This makes redis more stable. Deleting a node will not cause multiple redis node to stop simultaneusly.

*Note*: From now, there are needed the same amount of nodes than redis/sentinel pods.