### PR TITLE
Devops 650 allow multiple updates of same resource

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # The following are targers that do not exist in the filesystem as real files and should be always executed by make
 .PHONY: default build deps-development docker-build shell run image unit-test test generate go-generate get-deps update-deps
-VERSION := 0.1.4
+VERSION := 0.1.5
 
 # Name of this service/application
 SERVICE_NAME := redis-operator

--- a/pkg/failover/client.go
+++ b/pkg/failover/client.go
@@ -793,8 +793,16 @@ func (r *RedisFailoverKubeClient) UpdateRedisStatefulset(rf *RedisFailover) erro
 	oldSS.Spec.Template.Spec.Containers[0].Image = getRedisImage(rf)
 
 	if rf.Spec.Redis.Exporter {
-		exporter := createRedisExporterContainer()
-		oldSS.Spec.Template.Spec.Containers = append(oldSS.Spec.Template.Spec.Containers, exporter)
+		found := false
+		for _, container := range oldSS.Spec.Template.Spec.Containers {
+			if container.Name == exporterContainerName {
+				found = true
+			}
+		}
+		if !found {
+			exporter := createRedisExporterContainer()
+			oldSS.Spec.Template.Spec.Containers = append(oldSS.Spec.Template.Spec.Containers, exporter)
+		}
 	} else {
 		for pos, container := range oldSS.Spec.Template.Spec.Containers {
 			if container.Name == exporterContainerName {

--- a/pkg/failover/client.go
+++ b/pkg/failover/client.go
@@ -739,7 +739,6 @@ func (r *RedisFailoverKubeClient) createPodDisruptionBudget(rf *RedisFailover, n
 
 // UpdateSentinelDeployment updates the spec of the existing sentinel deployment
 func (r *RedisFailoverKubeClient) UpdateSentinelDeployment(rf *RedisFailover) error {
-	name := r.GetSentinelName(rf)
 	namespace := rf.Metadata.Namespace
 	logger := r.logger.WithField(logNameField, rf.Metadata.Name).WithField(logNamespaceField, rf.Metadata.Namespace)
 
@@ -766,11 +765,11 @@ func (r *RedisFailoverKubeClient) UpdateSentinelDeployment(rf *RedisFailover) er
 	oldSD.Spec.Template.Spec.Containers[0].Image = getRedisImage(rf)
 	oldSD.Spec.Template.Spec.Containers[0].Resources = getSentinelResources(rf.Spec)
 
-	if _, err := r.Client.AppsV1beta1().Deployments(namespace).Update(oldSD); err != nil {
+	if err := r.waitForStatefulset(r.GetRedisName(rf), namespace, rf.Spec.Redis.Replicas, logger); err != nil {
 		return err
 	}
 
-	if err := r.waitForDeployment(name, namespace, replicas, logger); err != nil {
+	if _, err := r.Client.AppsV1beta1().Deployments(namespace).Update(oldSD); err != nil {
 		return err
 	}
 
@@ -779,7 +778,6 @@ func (r *RedisFailoverKubeClient) UpdateSentinelDeployment(rf *RedisFailover) er
 
 // UpdateRedisStatefulset updates the spec of the existing redis statefulset
 func (r *RedisFailoverKubeClient) UpdateRedisStatefulset(rf *RedisFailover) error {
-	name := r.GetRedisName(rf)
 	namespace := rf.Metadata.Namespace
 	logger := r.logger.WithField(logNameField, rf.Metadata.Name).WithField(logNamespaceField, rf.Metadata.Namespace)
 
@@ -805,11 +803,11 @@ func (r *RedisFailoverKubeClient) UpdateRedisStatefulset(rf *RedisFailover) erro
 		}
 	}
 
-	if _, err := r.Client.AppsV1beta1().StatefulSets(namespace).Update(oldSS); err != nil {
+	if err := r.waitForDeployment(r.GetSentinelName(rf), namespace, rf.Spec.Sentinel.Replicas, logger); err != nil {
 		return err
 	}
 
-	if err := r.waitForStatefulset(name, namespace, replicas, logger); err != nil {
+	if _, err := r.Client.AppsV1beta1().StatefulSets(namespace).Update(oldSS); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
We have changed the way updates are done.

Until now, when the Redis statefulset was updated, it waited until the rolling update to be finished. The same happened with Sentinel with its deployment.

He have multiple premises in mind:
* Kubernetes deployments and statefulsets are trustworthly.
* Multiple updates on the same resource on k8s can be made.
* We don't want to update sentinel and redis at the same time to avoid failures.

So, from now, the updates don't wait to themselves to be finished. In stead, they check that the other resource is ready and there's no an update being done (to prevent simultaneous redis and sentinel updates).