### PR TITLE
Devops 657 add flag hard antiaffinity

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # The following are targers that do not exist in the filesystem as real files and should be always executed by make
-.PHONY: default build deps-development docker-build shell run image unit-test test generate go-generate get-deps update-deps
+.PHONY: default build deps-development docker-build shell run image unit-test test generate go-generate get-deps update-deps testing
 VERSION := 0.1.5
 
 # Name of this service/application
@@ -81,6 +81,10 @@ image: deps-development
 	-t $(REPOSITORY):$(BRANCH) \
 	-f $(APP_DIR)/Dockerfile \
 	.
+
+testing: image
+	docker push $(REPOSITORY):$(BRANCH)
+
 tag:
 	git tag $(VERSION)
 

--- a/README.md
+++ b/README.md
@@ -56,21 +56,22 @@ metadata:
   name: myredisfailover
   namespace: mynamespace
 spec:
+  hardAntiAffinity: false  # Optional. Value by default. If true, the pods will not be scheduled on the same node.
   sentinel:
-    replicas: 3        # Optional. Value by default, can be set higher.
-    resources:         # Optional. If not set, it won't be defined on created reosurces
+    replicas: 3            # Optional. Value by default, can be set higher.
+    resources:             # Optional. If not set, it won't be defined on created reosurces
       requests:
         cpu: 100m
       limits:
         memory: 100Mi
   redis:
-    replicas: 3        # Optional. Value by default, can be set higher.
-    resources:         # Optional. If not set, it won't be defined on created reosurces
+    replicas: 3            # Optional. Value by default, can be set higher.
+    resources:             # Optional. If not set, it won't be defined on created reosurces
       requests:
         cpu: 100m
       limits:
         memory: 100Mi
-    exporter: false    # Optional. False by default. Adds a redis-exporter container to export metrics.
+    exporter: false        # Optional. False by default. Adds a redis-exporter container to export metrics.
 ~~~~
 
 ## Creation pipeline
@@ -125,4 +126,3 @@ You can do the following commands with make:
 `make update-deps`
 * Build the app image.
 `make image`
-

--- a/pkg/failover/spec.go
+++ b/pkg/failover/spec.go
@@ -43,6 +43,10 @@ type RedisFailoverSpec struct {
 
 	// Sentinel defines its failover settings
 	Sentinel SentinelSettings `json:"sentinel,omitempty"`
+
+	// HardAntiAffinity defines if the PodAntiAffinity on the deployments and
+	// statefulsets has to be hard (it's soft by default)
+	HardAntiAffinity bool `json:"hardAntiAffinity,omitempty"`
 }
 
 // RedisFailover represents a Redis failover

--- a/pkg/failover/waiter.go
+++ b/pkg/failover/waiter.go
@@ -63,7 +63,7 @@ func (r *RedisFailoverKubeClient) waitForDeployment(name string, namespace strin
 		case <-t.C:
 			logger.Debug("Waiting for Sentinel deployment to be fully operative")
 			deployment, _ := r.Client.AppsV1beta1().Deployments(namespace).Get(name, metav1.GetOptions{})
-			if deployment.Status.ReadyReplicas == replicas {
+			if deployment.Status.ReadyReplicas == replicas && deployment.Status.Replicas == replicas {
 				return nil
 			}
 		case <-to:
@@ -82,7 +82,7 @@ func (r *RedisFailoverKubeClient) waitForStatefulset(name string, namespace stri
 		case <-t.C:
 			logger.Debug("Waiting for Redis statefulset to be fully operative")
 			statefulset, _ := r.Client.AppsV1beta1().StatefulSets(namespace).Get(name, metav1.GetOptions{})
-			if statefulset.Status.ReadyReplicas == replicas {
+			if statefulset.Status.ReadyReplicas == replicas && statefulset.Status.Replicas == replicas {
 				return nil
 			}
 		case <-to:


### PR DESCRIPTION
Leave the soft antiAffinity by default, but add the ability to set it to a hard one.

* Add new parameter to RF Spec.
* Simplify code by moving the affinity creation to a function.
* Add tests for affinity changes.