### PR TITLE
[Devops-738] Make sentinel.conf writable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION := 0.2.0
+VERSION := 0.2.1
 
 # Name of this service/application
 SERVICE_NAME := redis-operator

--- a/operator/redisfailover/service/check_test.go
+++ b/operator/redisfailover/service/check_test.go
@@ -170,7 +170,7 @@ func TestCheckAllSlavesFromMasterGetSlaveOfError(t *testing.T) {
 
 	pods := &corev1.PodList{
 		Items: []corev1.Pod{
-			corev1.Pod{
+			{
 				Status: corev1.PodStatus{
 					PodIP: "",
 				},
@@ -196,7 +196,7 @@ func TestCheckAllSlavesFromMasterDifferentMaster(t *testing.T) {
 
 	pods := &corev1.PodList{
 		Items: []corev1.Pod{
-			corev1.Pod{
+			{
 				Status: corev1.PodStatus{
 					PodIP: "0.0.0.0",
 				},
@@ -222,7 +222,7 @@ func TestCheckAllSlavesFromMaster(t *testing.T) {
 
 	pods := &corev1.PodList{
 		Items: []corev1.Pod{
-			corev1.Pod{
+			{
 				Status: corev1.PodStatus{
 					PodIP: "0.0.0.0",
 				},
@@ -263,7 +263,7 @@ func TestCheckSentinelNumberInMemoryGetNumberSentinelInMemoryError(t *testing.T)
 
 	pods := &corev1.PodList{
 		Items: []corev1.Pod{
-			corev1.Pod{
+			{
 				Status: corev1.PodStatus{
 					PodIP: "0.0.0.0",
 				},
@@ -289,7 +289,7 @@ func TestCheckSentinelNumberInMemoryNumberMismatch(t *testing.T) {
 
 	pods := &corev1.PodList{
 		Items: []corev1.Pod{
-			corev1.Pod{
+			{
 				Status: corev1.PodStatus{
 					PodIP: "0.0.0.0",
 				},
@@ -315,7 +315,7 @@ func TestCheckSentinelNumberInMemory(t *testing.T) {
 
 	pods := &corev1.PodList{
 		Items: []corev1.Pod{
-			corev1.Pod{
+			{
 				Status: corev1.PodStatus{
 					PodIP: "0.0.0.0",
 				},
@@ -356,7 +356,7 @@ func TestCheckSentinelSlavesNumberInMemoryGetNumberSentinelSlavesInMemoryError(t
 
 	pods := &corev1.PodList{
 		Items: []corev1.Pod{
-			corev1.Pod{
+			{
 				Status: corev1.PodStatus{
 					PodIP: "0.0.0.0",
 				},
@@ -382,7 +382,7 @@ func TestCheckSentinelSlavesNumberInMemoryReplicasMismatch(t *testing.T) {
 
 	pods := &corev1.PodList{
 		Items: []corev1.Pod{
-			corev1.Pod{
+			{
 				Status: corev1.PodStatus{
 					PodIP: "0.0.0.0",
 				},
@@ -408,7 +408,7 @@ func TestCheckSentinelSlavesNumberInMemory(t *testing.T) {
 
 	pods := &corev1.PodList{
 		Items: []corev1.Pod{
-			corev1.Pod{
+			{
 				Status: corev1.PodStatus{
 					PodIP: "0.0.0.0",
 				},
@@ -488,7 +488,7 @@ func TestGetMasterIPIsMasterError(t *testing.T) {
 
 	pods := &corev1.PodList{
 		Items: []corev1.Pod{
-			corev1.Pod{
+			{
 				Status: corev1.PodStatus{
 					PodIP: "0.0.0.0",
 				},
@@ -514,12 +514,12 @@ func TestGetMasterIPMultipleMastersError(t *testing.T) {
 
 	pods := &corev1.PodList{
 		Items: []corev1.Pod{
-			corev1.Pod{
+			{
 				Status: corev1.PodStatus{
 					PodIP: "0.0.0.0",
 				},
 			},
-			corev1.Pod{
+			{
 				Status: corev1.PodStatus{
 					PodIP: "1.1.1.1",
 				},
@@ -546,12 +546,12 @@ func TestGetMasterIP(t *testing.T) {
 
 	pods := &corev1.PodList{
 		Items: []corev1.Pod{
-			corev1.Pod{
+			{
 				Status: corev1.PodStatus{
 					PodIP: "0.0.0.0",
 				},
 			},
-			corev1.Pod{
+			{
 				Status: corev1.PodStatus{
 					PodIP: "1.1.1.1",
 				},
@@ -594,7 +594,7 @@ func TestGetNumberMastersIsMasterError(t *testing.T) {
 
 	pods := &corev1.PodList{
 		Items: []corev1.Pod{
-			corev1.Pod{
+			{
 				Status: corev1.PodStatus{
 					PodIP: "0.0.0.0",
 				},
@@ -620,12 +620,12 @@ func TestGetNumberMasters(t *testing.T) {
 
 	pods := &corev1.PodList{
 		Items: []corev1.Pod{
-			corev1.Pod{
+			{
 				Status: corev1.PodStatus{
 					PodIP: "0.0.0.0",
 				},
 			},
-			corev1.Pod{
+			{
 				Status: corev1.PodStatus{
 					PodIP: "1.1.1.1",
 				},
@@ -653,12 +653,12 @@ func TestGetNumberMastersTwo(t *testing.T) {
 
 	pods := &corev1.PodList{
 		Items: []corev1.Pod{
-			corev1.Pod{
+			{
 				Status: corev1.PodStatus{
 					PodIP: "0.0.0.0",
 				},
 			},
-			corev1.Pod{
+			{
 				Status: corev1.PodStatus{
 					PodIP: "1.1.1.1",
 				},
@@ -705,14 +705,14 @@ func TestGetMinimumRedisPodTime(t *testing.T) {
 
 	pods := &corev1.PodList{
 		Items: []corev1.Pod{
-			corev1.Pod{
+			{
 				Status: corev1.PodStatus{
 					StartTime: &metav1.Time{
 						Time: oneHour,
 					},
 				},
 			},
-			corev1.Pod{
+			{
 				Status: corev1.PodStatus{
 					StartTime: &metav1.Time{
 						Time: oneMinute,

--- a/operator/redisfailover/service/heal_test.go
+++ b/operator/redisfailover/service/heal_test.go
@@ -20,7 +20,7 @@ func TestSetRandomMasterNewMasterError(t *testing.T) {
 
 	pods := &corev1.PodList{
 		Items: []corev1.Pod{
-			corev1.Pod{
+			{
 				Status: corev1.PodStatus{
 					PodIP: "0.0.0.0",
 				},
@@ -46,7 +46,7 @@ func TestSetRandomMaster(t *testing.T) {
 
 	pods := &corev1.PodList{
 		Items: []corev1.Pod{
-			corev1.Pod{
+			{
 				Status: corev1.PodStatus{
 					PodIP: "0.0.0.0",
 				},
@@ -72,12 +72,12 @@ func TestSetRandomMasterMultiplePodsMakeSlaveOfError(t *testing.T) {
 
 	pods := &corev1.PodList{
 		Items: []corev1.Pod{
-			corev1.Pod{
+			{
 				Status: corev1.PodStatus{
 					PodIP: "0.0.0.0",
 				},
 			},
-			corev1.Pod{
+			{
 				Status: corev1.PodStatus{
 					PodIP: "1.1.1.1",
 				},
@@ -104,12 +104,12 @@ func TestSetRandomMasterMultiplePods(t *testing.T) {
 
 	pods := &corev1.PodList{
 		Items: []corev1.Pod{
-			corev1.Pod{
+			{
 				Status: corev1.PodStatus{
 					PodIP: "0.0.0.0",
 				},
 			},
-			corev1.Pod{
+			{
 				Status: corev1.PodStatus{
 					PodIP: "1.1.1.1",
 				},
@@ -136,12 +136,12 @@ func TestSetMasterOnAllMakeMasterError(t *testing.T) {
 
 	pods := &corev1.PodList{
 		Items: []corev1.Pod{
-			corev1.Pod{
+			{
 				Status: corev1.PodStatus{
 					PodIP: "0.0.0.0",
 				},
 			},
-			corev1.Pod{
+			{
 				Status: corev1.PodStatus{
 					PodIP: "1.1.1.1",
 				},
@@ -167,12 +167,12 @@ func TestSetMasterOnAllMakeSlaveOfError(t *testing.T) {
 
 	pods := &corev1.PodList{
 		Items: []corev1.Pod{
-			corev1.Pod{
+			{
 				Status: corev1.PodStatus{
 					PodIP: "0.0.0.0",
 				},
 			},
-			corev1.Pod{
+			{
 				Status: corev1.PodStatus{
 					PodIP: "1.1.1.1",
 				},
@@ -199,12 +199,12 @@ func TestSetMasterOnAll(t *testing.T) {
 
 	pods := &corev1.PodList{
 		Items: []corev1.Pod{
-			corev1.Pod{
+			{
 				Status: corev1.PodStatus{
 					PodIP: "0.0.0.0",
 				},
 			},
-			corev1.Pod{
+			{
 				Status: corev1.PodStatus{
 					PodIP: "1.1.1.1",
 				},


### PR DESCRIPTION
This fixes https://github.com/spotahome/redis-operator/issues/35

Proposed version to be released: 0.2.1

Bug cause:
* Redis Sentinel needs its configuration file to be writable
* Kubernetes had a security issue and from some versions, it does not allow to write on files mounted from a configmap, secret, etc

Solution:
* Create a initContainer for Sentinel Deployments that copy the file mounted from the configmap to a emptydir shared with the Sentinel container.

Extra:
* Simplify the files to improve the Go formatting standards. 