### PR TITLE
use redisImage instead of alpine

### DIFF
--- a/operator/redisfailover/service/generator.go
+++ b/operator/redisfailover/service/generator.go
@@ -262,7 +262,7 @@ func generateSentinelDeployment(rf *redisfailoverv1alpha2.RedisFailover, labels 
 					InitContainers: []corev1.Container{
 						{
 							Name:            "sentinel-config-copy",
-							Image:           "alpine",
+							Image:           redisImage,
 							ImagePullPolicy: "IfNotPresent",
 							VolumeMounts: []corev1.VolumeMount{
 								{


### PR DESCRIPTION
In our situation, we need to pull all images from our local registry when the deploy environment is offline. So we need to pull all online images and push them to the offline registry. The initContainer use online alpine only to do the `cp` job, we think may be we can use redis image instead of pulling another image. Since #52 enable us setting image and version manually, we can define our own image url.

Fixes # .

Changes proposed on the PR:
- use redisImage instead of alpine 