### PR TITLE
set redis role label

### DIFF
--- a/operator/redisfailover/checker.go
+++ b/operator/redisfailover/checker.go
@@ -67,6 +67,9 @@ func (r *RedisFailoverHandler) CheckAndHeal(rf *redisfailoverv1alpha2.RedisFailo
 			return err3
 		}
 	}
+	// make redis role lable in pod
+	r.rfHealer.SetRoleLable(master, rf)
+	
 	sentinels, err := r.rfChecker.GetSentinelsIPs(rf)
 	if err != nil {
 		return err

--- a/operator/redisfailover/service/constants.go
+++ b/operator/redisfailover/service/constants.go
@@ -40,4 +40,7 @@ const (
 	redisGroupName         = "mymaster"
 	appLabel               = "redis-failover"
 	hostnameTopologyKey    = "kubernetes.io/hostname"
+	redisRoleLabelName     = "RedisRole"
+	redisMaster            = "master"
+	redisSlave             = "slave"
 )

--- a/operator/redisfailover/service/heal.go
+++ b/operator/redisfailover/service/heal.go
@@ -87,17 +87,17 @@ func (r *RedisFailoverHealer) SetRoleLable(masterIP string, rf *redisfailoverv1a
 	if err != nil {
 		return err
 	}
+	redisRoleLable := map[string]string{redisRoleLabelName: ""}
 	for _, pod := range ssp.Items{
 		labels := pod.GetLabels()
 		if pod.Status.PodIP == masterIP{
 			r.logger.Debugf("Pod %s is master, updating pod labels as master", pod.Name)
-			master_label := map[string]string{"RedisRole": "master"}
-			labels = util.MergeLabels(labels, master_label)
+			redisRoleLable[redisRoleLabelName] = redisMaster
 		}else{
 			r.logger.Debugf("Pod %s is slave, updating pod labels as salve", pod.Name)
-			slave_label := map[string]string{"RedisRole": "slave"}
-			labels = util.MergeLabels(labels, slave_label)
+			redisRoleLable[redisRoleLabelName] = redisSlave
 		}
+		labels = util.MergeLabels(labels, redisRoleLable)
 		pod.SetLabels(labels)
 	}
 	return nil


### PR DESCRIPTION
Hi,

I found no services file about master/slave in the sample folder,  I want to use POD Label to select Redis role to do Service(master/slave).

Changes proposed on the PR:
-  Create master/slave label in pod.

