### PR TITLE
Elect a new master on sigterm

### DIFF
--- a/api/redisfailover/v1alpha2/types.go
+++ b/api/redisfailover/v1alpha2/types.go
@@ -35,15 +35,16 @@ type RedisFailoverSpec struct {
 
 // RedisSettings defines the specification of the redis cluster
 type RedisSettings struct {
-	Replicas        int32                  `json:"replicas,omitempty"`
-	Resources       RedisFailoverResources `json:"resources,omitempty"`
-	Exporter        bool                   `json:"exporter,omitempty"`
-	ExporterImage   string                 `json:"exporterImage,omitempty"`
-	ExporterVersion string                 `json:"exporterVersion,omitempty"`
-	Image           string                 `json:"image,omitempty"`
-	Version         string                 `json:"version,omitempty"`
-	ConfigMap       string                 `json:"configMap,omitempty"`
-	Storage         RedisStorage           `json:"storage,omitempty"`
+	Replicas          int32                  `json:"replicas,omitempty"`
+	Resources         RedisFailoverResources `json:"resources,omitempty"`
+	Exporter          bool                   `json:"exporter,omitempty"`
+	ExporterImage     string                 `json:"exporterImage,omitempty"`
+	ExporterVersion   string                 `json:"exporterVersion,omitempty"`
+	Image             string                 `json:"image,omitempty"`
+	Version           string                 `json:"version,omitempty"`
+	ConfigMap         string                 `json:"configMap,omitempty"`
+	ShutdownConfigMap string                 `json:"shutdownConfigMap,omitempty"`
+	Storage           RedisStorage           `json:"storage,omitempty"`
 }
 
 // SentinelSettings defines the specification of the sentinel cluster

--- a/charts/redisoperator/Chart.yaml
+++ b/charts/redisoperator/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for the Spotahome Redis Operator
 name: redisoperator
-version: 2.2.0
+version: 2.3.0

--- a/mocks/operator/redisfailover/service/RedisFailoverClient.go
+++ b/mocks/operator/redisfailover/service/RedisFailoverClient.go
@@ -39,6 +39,20 @@ func (_m *RedisFailoverClient) EnsureRedisConfigMap(rFailover *v1alpha2.RedisFai
 	return r0
 }
 
+// EnsureRedisShutdownConfigMap provides a mock function with given fields: rFailover, labels, ownerRefs
+func (_m *RedisFailoverClient) EnsureRedisShutdownConfigMap(rFailover *v1alpha2.RedisFailover, labels map[string]string, ownerRefs []v1.OwnerReference) error {
+	ret := _m.Called(rFailover, labels, ownerRefs)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(*v1alpha2.RedisFailover, map[string]string, []v1.OwnerReference) error); ok {
+		r0 = rf(rFailover, labels, ownerRefs)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 // EnsureRedisService provides a mock function with given fields: rFailover, labels, ownerRefs
 func (_m *RedisFailoverClient) EnsureRedisService(rFailover *v1alpha2.RedisFailover, labels map[string]string, ownerRefs []v1.OwnerReference) error {
 	ret := _m.Called(rFailover, labels, ownerRefs)

--- a/operator/redisfailover/ensurer.go
+++ b/operator/redisfailover/ensurer.go
@@ -22,6 +22,9 @@ func (w *RedisFailoverHandler) Ensure(rf *redisfailoverv1alpha2.RedisFailover, l
 	if err := w.rfService.EnsureSentinelConfigMap(rf, labels, or); err != nil {
 		return err
 	}
+	if err := w.rfService.EnsureRedisShutdownConfigMap(rf, labels, or); err != nil {
+		return err
+	}
 	if err := w.rfService.EnsureRedisConfigMap(rf, labels, or); err != nil {
 		return err
 	}

--- a/operator/redisfailover/ensurer_test.go
+++ b/operator/redisfailover/ensurer_test.go
@@ -86,6 +86,7 @@ func TestEnsure(t *testing.T) {
 			mrfs.On("EnsureSentinelService", rf, mock.Anything, mock.Anything).Once().Return(nil)
 			mrfs.On("EnsureSentinelConfigMap", rf, mock.Anything, mock.Anything).Once().Return(nil)
 			mrfs.On("EnsureRedisConfigMap", rf, mock.Anything, mock.Anything).Once().Return(nil)
+			mrfs.On("EnsureRedisShutdownConfigMap", rf, mock.Anything, mock.Anything).Once().Return(nil)
 			mrfs.On("EnsureRedisStatefulset", rf, mock.Anything, mock.Anything).Once().Return(nil)
 			mrfs.On("EnsureSentinelDeployment", rf, mock.Anything, mock.Anything).Once().Return(nil)
 

--- a/operator/redisfailover/service/client.go
+++ b/operator/redisfailover/service/client.go
@@ -96,7 +96,7 @@ func (r *RedisFailoverKubeClient) EnsureRedisConfigMap(rf *redisfailoverv1alpha2
 }
 
 func (r *RedisFailoverKubeClient) EnsureRedisShutdownConfigMap(rf *redisfailoverv1alpha2.RedisFailover, labels map[string]string, ownerRefs []metav1.OwnerReference) error {
-	if rf.Spec.Redis.ConfigMap != "" {
+	if rf.Spec.Redis.ShutdownConfigMap != "" {
 		if _, err := r.K8SService.GetConfigMap(rf.Namespace, rf.Spec.Redis.ShutdownConfigMap); err != nil {
 			return err
 		}

--- a/operator/redisfailover/service/constants.go
+++ b/operator/redisfailover/service/constants.go
@@ -36,6 +36,7 @@ const (
 	sentinelConfigFileName = "sentinel.conf"
 	redisConfigFileName    = "redis.conf"
 	redisName              = "r"
+	redisShutdownName              = "shutdown"
 	redisRoleName          = "redis"
 	redisGroupName         = "mymaster"
 	appLabel               = "redis-failover"

--- a/operator/redisfailover/service/constants.go
+++ b/operator/redisfailover/service/constants.go
@@ -36,7 +36,7 @@ const (
 	sentinelConfigFileName = "sentinel.conf"
 	redisConfigFileName    = "redis.conf"
 	redisName              = "r"
-	redisShutdownName              = "shutdown"
+	redisShutdownName      = "s-shutdown"
 	redisRoleName          = "redis"
 	redisGroupName         = "mymaster"
 	appLabel               = "redis-failover"

--- a/operator/redisfailover/service/constants.go
+++ b/operator/redisfailover/service/constants.go
@@ -36,7 +36,7 @@ const (
 	sentinelConfigFileName = "sentinel.conf"
 	redisConfigFileName    = "redis.conf"
 	redisName              = "r"
-	redisShutdownName      = "s-shutdown"
+	redisShutdownName      = "r-shutdown"
 	redisRoleName          = "redis"
 	redisGroupName         = "mymaster"
 	appLabel               = "redis-failover"

--- a/operator/redisfailover/service/generator.go
+++ b/operator/redisfailover/service/generator.go
@@ -588,7 +588,7 @@ func getRedisVolumes(rf *redisfailoverv1alpha2.RedisFailover) []corev1.Volume {
 	configMapName := GetRedisConfigMapName(rf)
 	shutdownConfigMapName := GetRedisShutdownConfigMapName(rf)
 
-	defaultMode := int32(0744)
+	executeMode := int32(0744)
 	volumes := []corev1.Volume{
 		{
 			Name: redisConfigurationVolumeName,
@@ -607,7 +607,7 @@ func getRedisVolumes(rf *redisfailoverv1alpha2.RedisFailover) []corev1.Volume {
 					LocalObjectReference: corev1.LocalObjectReference{
 						Name: shutdownConfigMapName,
 					},
-					DefaultMode: &defaultMode,
+					DefaultMode: &executeMode,
 				},
 			},
 		},

--- a/operator/redisfailover/service/generator.go
+++ b/operator/redisfailover/service/generator.go
@@ -15,8 +15,9 @@ import (
 )
 
 const (
-	redisConfigurationVolumeName = "redis-config"
-	redisStorageVolumeName       = "redis-data"
+	redisConfigurationVolumeName         = "redis-config"
+	redisShutdownConfigurationVolumeName = "redis-shutdown-config"
+	redisStorageVolumeName               = "redis-data"
 )
 
 func generateSentinelService(rf *redisfailoverv1alpha2.RedisFailover, labels map[string]string, ownerRefs []metav1.OwnerReference) *corev1.Service {
@@ -122,6 +123,28 @@ tcp-keepalive 60`,
 	}
 }
 
+func generateRedisShutdownConfigMap(rf *redisfailoverv1alpha2.RedisFailover, labels map[string]string, ownerRefs []metav1.OwnerReference) *corev1.ConfigMap {
+	name := GetRedisShutdownConfigMapName(rf)
+	namespace := rf.Namespace
+
+	labels = util.MergeLabels(labels, generateLabels(redisRoleName, rf.Name))
+
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            name,
+			Namespace:       namespace,
+			Labels:          labels,
+			OwnerReferences: ownerRefs,
+		},
+		Data: map[string]string{
+			"shutdown.sh": `master=$(redis-cli -h ${RFS_REDIS_SERVICE_HOST} -p ${RFS_REDIS_SERVICE_PORT_SENTINEL} --csv SENTINEL get-master-addr-by-name mymaster | tr ',' ' ' | tr -d '\"' |cut -d' ' -f1)
+if [[ $master ==  $(hostname -i) ]]; then
+  redis-cli -h ${RFS_REDIS_SERVICE_HOST} -p ${RFS_REDIS_SERVICE_PORT_SENTINEL} SENTINEL failover mymaster
+fi`,
+		},
+	}
+}
+
 func generateRedisStatefulSet(rf *redisfailoverv1alpha2.RedisFailover, labels map[string]string, ownerRefs []metav1.OwnerReference) *appsv1beta2.StatefulSet {
 	name := GetRedisName(rf)
 	namespace := rf.Namespace
@@ -202,6 +225,13 @@ func generateRedisStatefulSet(rf *redisfailoverv1alpha2.RedisFailover, labels ma
 								},
 							},
 							Resources: resources,
+							Lifecycle: &corev1.Lifecycle{
+								PreStop: &corev1.Handler{
+									Exec: &corev1.ExecAction{
+										Command: []string{"/bin/sh", "-c", "/redis-shutdown/shutdown.sh"},
+									},
+								},
+							},
 						},
 					},
 					Volumes: volumes,
@@ -542,6 +572,10 @@ func getRedisVolumeMounts(rf *redisfailoverv1alpha2.RedisFailover) []corev1.Volu
 			MountPath: "/redis",
 		},
 		{
+			Name:      redisShutdownConfigurationVolumeName,
+			MountPath: "/redis-shutdown",
+		},
+		{
 			Name:      getRedisDataVolumeName(rf),
 			MountPath: "/data",
 		},
@@ -552,7 +586,9 @@ func getRedisVolumeMounts(rf *redisfailoverv1alpha2.RedisFailover) []corev1.Volu
 
 func getRedisVolumes(rf *redisfailoverv1alpha2.RedisFailover) []corev1.Volume {
 	configMapName := GetRedisConfigMapName(rf)
+	shutdownConfigMapName := GetRedisShutdownConfigMapName(rf)
 
+	defaultMode := int32(0744)
 	volumes := []corev1.Volume{
 		{
 			Name: redisConfigurationVolumeName,
@@ -561,6 +597,17 @@ func getRedisVolumes(rf *redisfailoverv1alpha2.RedisFailover) []corev1.Volume {
 					LocalObjectReference: corev1.LocalObjectReference{
 						Name: configMapName,
 					},
+				},
+			},
+		},
+		{
+			Name: redisShutdownConfigurationVolumeName,
+			VolumeSource: corev1.VolumeSource{
+				ConfigMap: &corev1.ConfigMapVolumeSource{
+					LocalObjectReference: corev1.LocalObjectReference{
+						Name: shutdownConfigMapName,
+					},
+					DefaultMode: &defaultMode,
 				},
 			},
 		},

--- a/operator/redisfailover/service/generator_test.go
+++ b/operator/redisfailover/service/generator_test.go
@@ -18,6 +18,8 @@ import (
 
 func TestRedisStatefulSetStorageGeneration(t *testing.T) {
 	configMapName := rfservice.GetRedisConfigMapName(generateRF())
+	shutdownConfigMapName := rfservice.GetRedisShutdownConfigMapName(generateRF())
+	executeMode := int32(0744)
 	tests := []struct {
 		name           string
 		ownerRefs      []metav1.OwnerReference
@@ -38,6 +40,10 @@ func TestRedisStatefulSetStorageGeneration(t *testing.T) {
 											MountPath: "/redis",
 										},
 										{
+											Name:      "redis-shutdown-config",
+											MountPath: "/redis-shutdown",
+										},
+										{
 											Name:      "redis-data",
 											MountPath: "/data",
 										},
@@ -52,6 +58,17 @@ func TestRedisStatefulSetStorageGeneration(t *testing.T) {
 											LocalObjectReference: corev1.LocalObjectReference{
 												Name: configMapName,
 											},
+										},
+									},
+								},
+								{
+									Name: "redis-shutdown-config",
+									VolumeSource: corev1.VolumeSource{
+										ConfigMap: &corev1.ConfigMapVolumeSource{
+											LocalObjectReference: corev1.LocalObjectReference{
+												Name: shutdownConfigMapName,
+											},
+											DefaultMode: &executeMode,
 										},
 									},
 								},
@@ -82,6 +99,10 @@ func TestRedisStatefulSetStorageGeneration(t *testing.T) {
 											MountPath: "/redis",
 										},
 										{
+											Name:      "redis-shutdown-config",
+											MountPath: "/redis-shutdown",
+										},
+										{
 											Name:      "redis-data",
 											MountPath: "/data",
 										},
@@ -96,6 +117,17 @@ func TestRedisStatefulSetStorageGeneration(t *testing.T) {
 											LocalObjectReference: corev1.LocalObjectReference{
 												Name: configMapName,
 											},
+										},
+									},
+								},
+								{
+									Name: "redis-shutdown-config",
+									VolumeSource: corev1.VolumeSource{
+										ConfigMap: &corev1.ConfigMapVolumeSource{
+											LocalObjectReference: corev1.LocalObjectReference{
+												Name: shutdownConfigMapName,
+											},
+											DefaultMode: &executeMode,
 										},
 									},
 								},
@@ -132,6 +164,10 @@ func TestRedisStatefulSetStorageGeneration(t *testing.T) {
 											MountPath: "/redis",
 										},
 										{
+											Name:      "redis-shutdown-config",
+											MountPath: "/redis-shutdown",
+										},
+										{
 											Name:      "pvc-data",
 											MountPath: "/data",
 										},
@@ -146,6 +182,17 @@ func TestRedisStatefulSetStorageGeneration(t *testing.T) {
 											LocalObjectReference: corev1.LocalObjectReference{
 												Name: configMapName,
 											},
+										},
+									},
+								},
+								{
+									Name: "redis-shutdown-config",
+									VolumeSource: corev1.VolumeSource{
+										ConfigMap: &corev1.ConfigMapVolumeSource{
+											LocalObjectReference: corev1.LocalObjectReference{
+												Name: shutdownConfigMapName,
+											},
+											DefaultMode: &executeMode,
 										},
 									},
 								},
@@ -208,6 +255,10 @@ func TestRedisStatefulSetStorageGeneration(t *testing.T) {
 											MountPath: "/redis",
 										},
 										{
+											Name:      "redis-shutdown-config",
+											MountPath: "/redis-shutdown",
+										},
+										{
 											Name:      "pvc-data",
 											MountPath: "/data",
 										},
@@ -222,6 +273,17 @@ func TestRedisStatefulSetStorageGeneration(t *testing.T) {
 											LocalObjectReference: corev1.LocalObjectReference{
 												Name: configMapName,
 											},
+										},
+									},
+								},
+								{
+									Name: "redis-shutdown-config",
+									VolumeSource: corev1.VolumeSource{
+										ConfigMap: &corev1.ConfigMapVolumeSource{
+											LocalObjectReference: corev1.LocalObjectReference{
+												Name: shutdownConfigMapName,
+											},
+											DefaultMode: &executeMode,
 										},
 									},
 								},
@@ -289,6 +351,10 @@ func TestRedisStatefulSetStorageGeneration(t *testing.T) {
 											MountPath: "/redis",
 										},
 										{
+											Name:      "redis-shutdown-config",
+											MountPath: "/redis-shutdown",
+										},
+										{
 											Name:      "pvc-data",
 											MountPath: "/data",
 										},
@@ -303,6 +369,17 @@ func TestRedisStatefulSetStorageGeneration(t *testing.T) {
 											LocalObjectReference: corev1.LocalObjectReference{
 												Name: configMapName,
 											},
+										},
+									},
+								},
+								{
+									Name: "redis-shutdown-config",
+									VolumeSource: corev1.VolumeSource{
+										ConfigMap: &corev1.ConfigMapVolumeSource{
+											LocalObjectReference: corev1.LocalObjectReference{
+												Name: shutdownConfigMapName,
+											},
+											DefaultMode: &executeMode,
 										},
 									},
 								},

--- a/operator/redisfailover/service/names.go
+++ b/operator/redisfailover/service/names.go
@@ -19,19 +19,18 @@ func GetRedisShutdownConfigMapName(rf *redisfailoverv1alpha2.RedisFailover) stri
 	if rf.Spec.Redis.ShutdownConfigMap != "" {
 		return rf.Spec.Redis.ShutdownConfigMap
 	}
-	return GetRedisShowDownName(rf)
+	return GetRedisShutdownName(rf)
 }
 
 // GetRedisName returns the name for redis resources
 func GetRedisName(rf *redisfailoverv1alpha2.RedisFailover) string {
 	return generateName(redisName, rf.Name)
 }
+
 // GetRedisName returns the name for redis resources
-func GetRedisShowDownName(rf *redisfailoverv1alpha2.RedisFailover) string {
+func GetRedisShutdownName(rf *redisfailoverv1alpha2.RedisFailover) string {
 	return generateName(redisShutdownName, rf.Name)
 }
-
-
 
 // GetSentinelConfigMapName returns the name for sentinel configmap
 func GetSentinelConfigMapName(rf *redisfailoverv1alpha2.RedisFailover) string {

--- a/operator/redisfailover/service/names.go
+++ b/operator/redisfailover/service/names.go
@@ -14,10 +14,24 @@ func GetRedisConfigMapName(rf *redisfailoverv1alpha2.RedisFailover) string {
 	return GetRedisName(rf)
 }
 
+// GetRedisShutdownConfigMapName returns the name for redis configmap
+func GetRedisShutdownConfigMapName(rf *redisfailoverv1alpha2.RedisFailover) string {
+	if rf.Spec.Redis.ShutdownConfigMap != "" {
+		return rf.Spec.Redis.ShutdownConfigMap
+	}
+	return GetRedisShowDownName(rf)
+}
+
 // GetRedisName returns the name for redis resources
 func GetRedisName(rf *redisfailoverv1alpha2.RedisFailover) string {
 	return generateName(redisName, rf.Name)
 }
+// GetRedisName returns the name for redis resources
+func GetRedisShowDownName(rf *redisfailoverv1alpha2.RedisFailover) string {
+	return generateName(redisShutdownName, rf.Name)
+}
+
+
 
 // GetSentinelConfigMapName returns the name for sentinel configmap
 func GetSentinelConfigMapName(rf *redisfailoverv1alpha2.RedisFailover) string {


### PR DESCRIPTION
I have added a config shutdown script that check if a node is master on sigterm.  If it is currently a master a request to elect another master is made.  This is to fix issues when a pod is killed for whatever reason and keep downtime from 30 seconds to none.