### PR TITLE
[DEVOPS-819] Add configuration to persist data

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION := 0.5.0
+VERSION := 0.5.1
 
 # Name of this service/application
 SERVICE_NAME := redis-operator

--- a/operator/redisfailover/service/generator.go
+++ b/operator/redisfailover/service/generator.go
@@ -118,7 +118,9 @@ func generateRedisConfigMap(rf *redisfailoverv1alpha2.RedisFailover, labels map[
 		},
 		Data: map[string]string{
 			redisConfigFileName: `slaveof 127.0.0.1 6379
-tcp-keepalive 60`,
+tcp-keepalive 60
+save 900 1
+save 300 10`,
 		},
 	}
 }
@@ -139,6 +141,7 @@ func generateRedisShutdownConfigMap(rf *redisfailoverv1alpha2.RedisFailover, lab
 		Data: map[string]string{
 			"shutdown.sh": `master=$(redis-cli -h ${RFS_REDIS_SERVICE_HOST} -p ${RFS_REDIS_SERVICE_PORT_SENTINEL} --csv SENTINEL get-master-addr-by-name mymaster | tr ',' ' ' | tr -d '\"' |cut -d' ' -f1)
 if [[ $master ==  $(hostname -i) ]]; then
+  redis-cli SAVE
   redis-cli -h ${RFS_REDIS_SERVICE_HOST} -p ${RFS_REDIS_SERVICE_PORT_SENTINEL} SENTINEL failover mymaster
 fi`,
 		},

--- a/operator/redisfailover/service/generator.go
+++ b/operator/redisfailover/service/generator.go
@@ -140,8 +140,8 @@ func generateRedisShutdownConfigMap(rf *redisfailoverv1alpha2.RedisFailover, lab
 		},
 		Data: map[string]string{
 			"shutdown.sh": `master=$(redis-cli -h ${RFS_REDIS_SERVICE_HOST} -p ${RFS_REDIS_SERVICE_PORT_SENTINEL} --csv SENTINEL get-master-addr-by-name mymaster | tr ',' ' ' | tr -d '\"' |cut -d' ' -f1)
+redis-cli SAVE
 if [[ $master ==  $(hostname -i) ]]; then
-  redis-cli SAVE
   redis-cli -h ${RFS_REDIS_SERVICE_HOST} -p ${RFS_REDIS_SERVICE_PORT_SENTINEL} SENTINEL failover mymaster
 fi`,
 		},


### PR DESCRIPTION
Fixes #77 .

Changes proposed on the PR:
- Add configuration to save periodically the database on disk, also on shutdown.

Image ready to be tested: quay.io/spotahome/redis-operator:devops-819-add-configuration-to-persist-data