### PR TITLE
Update chart to apps/v1 and rbac v1 deployment versions

### DIFF
--- a/charts/redisoperator/Chart.yaml
+++ b/charts/redisoperator/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for the Spotahome Redis Operator
 name: redisoperator
-version: 2.3.0
+version: 2.4.0

--- a/charts/redisoperator/templates/deployment.yaml
+++ b/charts/redisoperator/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2
+apiVersion: {{ .Values.apiVersion }}
 kind: Deployment
 metadata:
   name: {{ include "name" . | quote }}

--- a/charts/redisoperator/values.yaml
+++ b/charts/redisoperator/values.yaml
@@ -1,4 +1,5 @@
 replicaCount: 1
+apiVersion: apps/v1
 image: quay.io/spotahome/redis-operator
 tag: latest
 pullPolicy: Always
@@ -14,5 +15,5 @@ resources:
     memory: 50Mi
 rbac:
   install: false
-  apiVersion: v1beta1
+  apiVersion: v1
   imagePullSecrets: []


### PR DESCRIPTION
Clusters above 1.9 support apps/v1 as deployment version and rbac version of v1
Older deployment versions are deprecated
Provided flexiblity in chart so an older apiVersion can still be specified