### PR TITLE
[DEVOPS-824] Maximum name length

### DIFF
--- a/operator/redisfailover/checker.go
+++ b/operator/redisfailover/checker.go
@@ -43,6 +43,7 @@ func (r *RedisFailoverHandler) CheckAndHeal(rf *redisfailoverv1alpha2.RedisFailo
 			r.logger.Debugf("Time %.f more than expected. Not even one master, fixing...", minTime.Round(time.Second).Seconds())
 			// We can consider there's an error
 			if err2 := r.rfHealer.SetRandomMaster(rf); err2 != nil {
+				r.mClient.SetClusterError(rf.Namespace, rf.Name)
 				return err2
 			}
 		} else {
@@ -86,6 +87,7 @@ func (r *RedisFailoverHandler) CheckAndHeal(rf *redisfailoverv1alpha2.RedisFailo
 		if err := r.rfChecker.CheckSentinelMonitor(sip, master); err != nil {
 			r.logger.Debug("Sentinel is not monitoring the correct master")
 			if err := r.rfHealer.NewSentinelMonitor(sip, master, rf); err != nil {
+				r.mClient.SetClusterError(rf.Namespace, rf.Name)
 				return err
 			}
 		}

--- a/operator/redisfailover/service/client.go
+++ b/operator/redisfailover/service/client.go
@@ -117,7 +117,7 @@ func (r *RedisFailoverKubeClient) ensurePodDisruptionBudget(rf *redisfailoverv1a
 	namespace := rf.Namespace
 
 	minAvailable := intstr.FromInt(2)
-	labels = util.MergeLabels(labels, generateLabels(component, rf.Name))
+	labels = util.MergeLabels(labels, generateLabels(component, name))
 
 	pdb := generatePodDisruptionBudget(name, namespace, labels, ownerRefs, minAvailable)
 

--- a/operator/redisfailover/service/generator.go
+++ b/operator/redisfailover/service/generator.go
@@ -27,7 +27,7 @@ func generateSentinelService(rf *redisfailoverv1alpha2.RedisFailover, labels map
 	namespace := rf.Namespace
 
 	sentinelTargetPort := intstr.FromInt(26379)
-	labels = util.MergeLabels(labels, generateLabels(sentinelRoleName, rf.Name))
+	labels = util.MergeLabels(labels, generateLabels(sentinelRoleName, name))
 
 	return &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
@@ -54,7 +54,7 @@ func generateRedisService(rf *redisfailoverv1alpha2.RedisFailover, labels map[st
 	name := GetRedisName(rf)
 	namespace := rf.Namespace
 
-	labels = util.MergeLabels(labels, generateLabels(redisRoleName, rf.Name))
+	labels = util.MergeLabels(labels, generateLabels(redisRoleName, name))
 
 	return &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
@@ -87,7 +87,7 @@ func generateSentinelConfigMap(rf *redisfailoverv1alpha2.RedisFailover, labels m
 	name := GetSentinelName(rf)
 	namespace := rf.Namespace
 
-	labels = util.MergeLabels(labels, generateLabels(sentinelRoleName, rf.Name))
+	labels = util.MergeLabels(labels, generateLabels(sentinelRoleName, name))
 
 	return &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
@@ -109,7 +109,7 @@ func generateRedisConfigMap(rf *redisfailoverv1alpha2.RedisFailover, labels map[
 	name := GetRedisName(rf)
 	namespace := rf.Namespace
 
-	labels = util.MergeLabels(labels, generateLabels(redisRoleName, rf.Name))
+	labels = util.MergeLabels(labels, generateLabels(redisRoleName, name))
 
 	return &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
@@ -131,7 +131,7 @@ func generateRedisShutdownConfigMap(rf *redisfailoverv1alpha2.RedisFailover, lab
 	name := GetRedisShutdownConfigMapName(rf)
 	namespace := rf.Namespace
 
-	labels = util.MergeLabels(labels, generateLabels(redisRoleName, rf.Name))
+	labels = util.MergeLabels(labels, generateLabels(redisRoleName, name))
 
 	return &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
@@ -157,7 +157,7 @@ func generateRedisStatefulSet(rf *redisfailoverv1alpha2.RedisFailover, labels ma
 	spec := rf.Spec
 	redisImage := getRedisImage(rf)
 	resources := getRedisResources(spec)
-	labels = util.MergeLabels(labels, generateLabels(redisRoleName, rf.Name))
+	labels = util.MergeLabels(labels, generateLabels(redisRoleName, name))
 	volumeMounts := getRedisVolumeMounts(rf)
 	volumes := getRedisVolumes(rf)
 
@@ -271,7 +271,7 @@ func generateSentinelDeployment(rf *redisfailoverv1alpha2.RedisFailover, labels 
 	spec := rf.Spec
 	redisImage := getRedisImage(rf)
 	resources := getSentinelResources(spec)
-	labels = util.MergeLabels(labels, generateLabels(sentinelRoleName, rf.Name))
+	labels = util.MergeLabels(labels, generateLabels(sentinelRoleName, name))
 
 	return &appsv1beta2.Deployment{
 		ObjectMeta: metav1.ObjectMeta{

--- a/operator/redisfailover/service/names.go
+++ b/operator/redisfailover/service/names.go
@@ -6,6 +6,10 @@ import (
 	redisfailoverv1alpha2 "github.com/spotahome/redis-operator/api/redisfailover/v1alpha2"
 )
 
+const (
+	maxNameLength = 60
+)
+
 // GetRedisShutdownConfigMapName returns the name for redis configmap
 func GetRedisShutdownConfigMapName(rf *redisfailoverv1alpha2.RedisFailover) string {
 	if rf.Spec.Redis.ShutdownConfigMap != "" {
@@ -30,5 +34,14 @@ func GetSentinelName(rf *redisfailoverv1alpha2.RedisFailover) string {
 }
 
 func generateName(typeName, metaName string) string {
-	return fmt.Sprintf("%s%s-%s", baseName, typeName, metaName)
+	generatedName := fmt.Sprintf("%s%s-%s", baseName, typeName, metaName)
+
+	// If lenth higher than 60 characters, truncate the name so it does not cause problem when creating resources
+	// Applicable for names and labels
+	// https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#syntax-and-character-set
+	if len(generatedName) > maxNameLength {
+		generatedName = generatedName[:maxNameLength]
+	}
+
+	return generatedName
 }


### PR DESCRIPTION
* Fix: Truncate names up to 60 characters.
* Improvement: Set the RF as failed if important heals return an error