### PR TITLE
Create flag to toggle Redis exporter probes

### DIFF
--- a/api/redisfailover/v1alpha2/defaults.go
+++ b/api/redisfailover/v1alpha2/defaults.go
@@ -5,7 +5,6 @@ const (
 	defaultSentinelNumber       = 3
 	defaultExporterImage        = "oliver006/redis_exporter"
 	defaultExporterImageVersion = "v0.11.3"
-	defaultExporterProbes       = true
 	defaultRedisImage           = "redis"
 	defaultRedisImageVersion    = "3.2-alpine"
 )

--- a/api/redisfailover/v1alpha2/defaults.go
+++ b/api/redisfailover/v1alpha2/defaults.go
@@ -5,6 +5,7 @@ const (
 	defaultSentinelNumber       = 3
 	defaultExporterImage        = "oliver006/redis_exporter"
 	defaultExporterImageVersion = "v0.11.3"
+	defaultExporterProbes       = true
 	defaultRedisImage           = "redis"
 	defaultRedisImageVersion    = "3.2-alpine"
 )

--- a/api/redisfailover/v1alpha2/types.go
+++ b/api/redisfailover/v1alpha2/types.go
@@ -40,6 +40,7 @@ type RedisSettings struct {
 	Exporter          bool                   `json:"exporter,omitempty"`
 	ExporterImage     string                 `json:"exporterImage,omitempty"`
 	ExporterVersion   string                 `json:"exporterVersion,omitempty"`
+	ExporterProbes    bool                   `json:"exporterProbes,omitempty"`
 	Image             string                 `json:"image,omitempty"`
 	Version           string                 `json:"version,omitempty"`
 	CustomConfig      []string               `json:"customConfig,omitempty"`

--- a/api/redisfailover/v1alpha2/types.go
+++ b/api/redisfailover/v1alpha2/types.go
@@ -35,17 +35,17 @@ type RedisFailoverSpec struct {
 
 // RedisSettings defines the specification of the redis cluster
 type RedisSettings struct {
-	Replicas          int32                  `json:"replicas,omitempty"`
-	Resources         RedisFailoverResources `json:"resources,omitempty"`
-	Exporter          bool                   `json:"exporter,omitempty"`
-	ExporterImage     string                 `json:"exporterImage,omitempty"`
-	ExporterVersion   string                 `json:"exporterVersion,omitempty"`
-	ExporterProbes    bool                   `json:"exporterProbes,omitempty"`
-	Image             string                 `json:"image,omitempty"`
-	Version           string                 `json:"version,omitempty"`
-	CustomConfig      []string               `json:"customConfig,omitempty"`
-	ShutdownConfigMap string                 `json:"shutdownConfigMap,omitempty"`
-	Storage           RedisStorage           `json:"storage,omitempty"`
+	Replicas              int32                  `json:"replicas,omitempty"`
+	Resources             RedisFailoverResources `json:"resources,omitempty"`
+	Exporter              bool                   `json:"exporter,omitempty"`
+	ExporterImage         string                 `json:"exporterImage,omitempty"`
+	ExporterVersion       string                 `json:"exporterVersion,omitempty"`
+	DisableExporterProbes bool                   `json:"disableExporterProbes,omitempty"`
+	Image                 string                 `json:"image,omitempty"`
+	Version               string                 `json:"version,omitempty"`
+	CustomConfig          []string               `json:"customConfig,omitempty"`
+	ShutdownConfigMap     string                 `json:"shutdownConfigMap,omitempty"`
+	Storage               RedisStorage           `json:"storage,omitempty"`
 }
 
 // SentinelSettings defines the specification of the sentinel cluster

--- a/example/redisfailover/all-options.yaml
+++ b/example/redisfailover/all-options.yaml
@@ -26,7 +26,7 @@ spec:
     exporter: false                          # Optional. False by default. Adds a redis-exporter container to export metrics.
     exporterImage: oliver006/redis_exporter  # Optional. oliver006/redis_exporter by default.
     exporterVersion: v0.11.3                 # Optional. v0.11.3 by default.
-    exporterProbes: true                     # Optional. True by default. Enables the readiness and liveness probes for the exporter.
+    disableExporterProbes: false             # Optional. False by default. Disables the readiness and liveness probes for the exporter.
     storage:
       emptyDir: {}                           # Optional. emptyDir by default.
     customConfig: []                         # Optional. Empty by default.

--- a/example/redisfailover/all-options.yaml
+++ b/example/redisfailover/all-options.yaml
@@ -26,7 +26,7 @@ spec:
     exporter: false                          # Optional. False by default. Adds a redis-exporter container to export metrics.
     exporterImage: oliver006/redis_exporter  # Optional. oliver006/redis_exporter by default.
     exporterVersion: v0.11.3                 # Optional. v0.11.3 by default.
+    exporterProbes: true                     # Optional. True by default. Enables the readiness and liveness probes for the exporter.
     storage:
       emptyDir: {}                           # Optional. emptyDir by default.
     customConfig: []                         # Optional. Empty by default.
-

--- a/operator/redisfailover/service/generator.go
+++ b/operator/redisfailover/service/generator.go
@@ -454,6 +454,31 @@ func generateResourceList(cpu string, memory string) corev1.ResourceList {
 
 func createRedisExporterContainer(rf *redisfailoverv1alpha2.RedisFailover) corev1.Container {
 	exporterImage := getRedisExporterImage(rf)
+
+	var readinessProbe, livenessProbe *corev1.Probe
+	if rf.Spec.Redis.ExporterProbes {
+		readinessProbe = &corev1.Probe{
+			InitialDelaySeconds: 10,
+			TimeoutSeconds:      3,
+			Handler: corev1.Handler{
+				HTTPGet: &corev1.HTTPGetAction{
+					Path: "/",
+					Port: intstr.FromString("metrics"),
+				},
+			},
+		}
+
+		livenessProbe = &corev1.Probe{
+			TimeoutSeconds: 3,
+			Handler: corev1.Handler{
+				HTTPGet: &corev1.HTTPGetAction{
+					Path: "/",
+					Port: intstr.FromString("metrics"),
+				},
+			},
+		}
+	}
+
 	return corev1.Container{
 		Name:            exporterContainerName,
 		Image:           exporterImage,
@@ -475,25 +500,8 @@ func createRedisExporterContainer(rf *redisfailoverv1alpha2.RedisFailover) corev
 				Protocol:      corev1.ProtocolTCP,
 			},
 		},
-		ReadinessProbe: &corev1.Probe{
-			InitialDelaySeconds: 10,
-			TimeoutSeconds:      3,
-			Handler: corev1.Handler{
-				HTTPGet: &corev1.HTTPGetAction{
-					Path: "/",
-					Port: intstr.FromString("metrics"),
-				},
-			},
-		},
-		LivenessProbe: &corev1.Probe{
-			TimeoutSeconds: 3,
-			Handler: corev1.Handler{
-				HTTPGet: &corev1.HTTPGetAction{
-					Path: "/",
-					Port: intstr.FromString("metrics"),
-				},
-			},
-		},
+		ReadinessProbe: readinessProbe,
+		LivenessProbe:  livenessProbe,
 		Resources: corev1.ResourceRequirements{
 			Limits: corev1.ResourceList{
 				corev1.ResourceCPU:    resource.MustParse(exporterDefaultLimitCPU),

--- a/operator/redisfailover/service/generator.go
+++ b/operator/redisfailover/service/generator.go
@@ -455,8 +455,9 @@ func generateResourceList(cpu string, memory string) corev1.ResourceList {
 func createRedisExporterContainer(rf *redisfailoverv1alpha2.RedisFailover) corev1.Container {
 	exporterImage := getRedisExporterImage(rf)
 
+	// Define readiness and liveness probes only if config option to disable isn't set
 	var readinessProbe, livenessProbe *corev1.Probe
-	if rf.Spec.Redis.ExporterProbes {
+	if !rf.Spec.Redis.DisableExporterProbes {
 		readinessProbe = &corev1.Probe{
 			InitialDelaySeconds: 10,
 			TimeoutSeconds:      3,


### PR DESCRIPTION
The default exporter image listens for HTTP probes but a custom
image is not guaranteed to have the same behavior. This change
introduces a boolean value `exporterProbes` to let the user turn
off the readiness/liveness probes.

Fixes #84 