### PR TITLE
[DEVOPS-855] Make check&heal more resilient

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION := 0.5.3
+VERSION := 0.5.4
 
 # Name of this service/application
 SERVICE_NAME := redis-operator

--- a/mocks/operator/redisfailover/service/RedisFailoverHeal.go
+++ b/mocks/operator/redisfailover/service/RedisFailoverHeal.go
@@ -66,8 +66,8 @@ func (_m *RedisFailoverHeal) SetMasterOnAll(masterIP string, rFailover *v1alpha2
 	return r0
 }
 
-// SetRandomMaster provides a mock function with given fields: rFailover
-func (_m *RedisFailoverHeal) SetRandomMaster(rFailover *v1alpha2.RedisFailover) error {
+// SetOldestAsMaster provides a mock function with given fields: rFailover
+func (_m *RedisFailoverHeal) SetOldestAsMaster(rFailover *v1alpha2.RedisFailover) error {
 	ret := _m.Called(rFailover)
 
 	var r0 error

--- a/mocks/operator/redisfailover/service/RedisFailoverHeal.go
+++ b/mocks/operator/redisfailover/service/RedisFailoverHeal.go
@@ -10,6 +10,20 @@ type RedisFailoverHeal struct {
 	mock.Mock
 }
 
+// MakeMaster provides a mock function with given fields: ip
+func (_m *RedisFailoverHeal) MakeMaster(ip string) error {
+	ret := _m.Called(ip)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(string) error); ok {
+		r0 = rf(ip)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 // NewSentinelMonitor provides a mock function with given fields: ip, monitor, rFailover
 func (_m *RedisFailoverHeal) NewSentinelMonitor(ip string, monitor string, rFailover *v1alpha2.RedisFailover) error {
 	ret := _m.Called(ip, monitor, rFailover)

--- a/operator/redisfailover/checker.go
+++ b/operator/redisfailover/checker.go
@@ -35,12 +35,22 @@ func (r *RedisFailoverHandler) CheckAndHeal(rf *redisfailoverv1alpha2.RedisFailo
 	}
 	switch nMasters {
 	case 0:
+		redisesIP, err := r.rfChecker.GetRedisesIPs(rf)
+		if err != nil {
+			return err
+		}
+		if len(redisesIP) == 1 {
+			if err := r.rfHealer.MakeMaster(redisesIP[0]); err != nil {
+				return err
+			}
+			break
+		}
 		minTime, err2 := r.rfChecker.GetMinimumRedisPodTime(rf)
 		if err2 != nil {
 			return err2
 		}
 		if minTime > timeToPrepare {
-			r.logger.Debugf("Time %.f more than expected. Not even one master, fixing...", minTime.Round(time.Second).Seconds())
+			r.logger.Debugf("time %.f more than expected. Not even one master, fixing...", minTime.Round(time.Second).Seconds())
 			// We can consider there's an error
 			if err2 := r.rfHealer.SetRandomMaster(rf); err2 != nil {
 				r.mClient.SetClusterError(rf.Namespace, rf.Name)

--- a/operator/redisfailover/checker.go
+++ b/operator/redisfailover/checker.go
@@ -52,7 +52,7 @@ func (r *RedisFailoverHandler) CheckAndHeal(rf *redisfailoverv1alpha2.RedisFailo
 		if minTime > timeToPrepare {
 			r.logger.Debugf("time %.f more than expected. Not even one master, fixing...", minTime.Round(time.Second).Seconds())
 			// We can consider there's an error
-			if err2 := r.rfHealer.SetRandomMaster(rf); err2 != nil {
+			if err2 := r.rfHealer.SetOldestAsMaster(rf); err2 != nil {
 				r.mClient.SetClusterError(rf.Namespace, rf.Name)
 				return err2
 			}

--- a/operator/redisfailover/checker_test.go
+++ b/operator/redisfailover/checker_test.go
@@ -147,7 +147,7 @@ func TestCheckAndHeal(t *testing.T) {
 				}
 				if test.forceNewMaster {
 					mrfc.On("GetMinimumRedisPodTime", rf).Once().Return(1*time.Hour, nil)
-					mrfh.On("SetRandomMaster", rf).Once().Return(nil)
+					mrfh.On("SetOldestAsMaster", rf).Once().Return(nil)
 				} else {
 					mrfc.On("GetMinimumRedisPodTime", rf).Once().Return(1*time.Second, nil)
 					continueTests = false

--- a/operator/redisfailover/service/check.go
+++ b/operator/redisfailover/service/check.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"time"
 
+	corev1 "k8s.io/api/core/v1"
+
 	redisfailoverv1alpha2 "github.com/spotahome/redis-operator/api/redisfailover/v1alpha2"
 	"github.com/spotahome/redis-operator/log"
 	"github.com/spotahome/redis-operator/service/k8s"
@@ -180,7 +182,9 @@ func (r *RedisFailoverChecker) GetRedisesIPs(rf *redisfailoverv1alpha2.RedisFail
 		return nil, err
 	}
 	for _, rp := range rps.Items {
-		redises = append(redises, rp.Status.PodIP)
+		if rp.Status.Phase == corev1.PodRunning { // Only work with running pods
+			redises = append(redises, rp.Status.PodIP)
+		}
 	}
 	return redises, nil
 }
@@ -193,7 +197,9 @@ func (r *RedisFailoverChecker) GetSentinelsIPs(rf *redisfailoverv1alpha2.RedisFa
 		return nil, err
 	}
 	for _, sp := range rps.Items {
-		sentinels = append(sentinels, sp.Status.PodIP)
+		if sp.Status.Phase == corev1.PodRunning { // Only work with running pods
+			sentinels = append(sentinels, sp.Status.PodIP)
+		}
 	}
 	return sentinels, nil
 }

--- a/operator/redisfailover/service/check_test.go
+++ b/operator/redisfailover/service/check_test.go
@@ -173,6 +173,7 @@ func TestCheckAllSlavesFromMasterGetSlaveOfError(t *testing.T) {
 			{
 				Status: corev1.PodStatus{
 					PodIP: "",
+					Phase: corev1.PodRunning,
 				},
 			},
 		},
@@ -199,6 +200,7 @@ func TestCheckAllSlavesFromMasterDifferentMaster(t *testing.T) {
 			{
 				Status: corev1.PodStatus{
 					PodIP: "0.0.0.0",
+					Phase: corev1.PodRunning,
 				},
 			},
 		},
@@ -225,6 +227,7 @@ func TestCheckAllSlavesFromMaster(t *testing.T) {
 			{
 				Status: corev1.PodStatus{
 					PodIP: "0.0.0.0",
+					Phase: corev1.PodRunning,
 				},
 			},
 		},
@@ -266,6 +269,7 @@ func TestCheckSentinelNumberInMemoryGetNumberSentinelInMemoryError(t *testing.T)
 			{
 				Status: corev1.PodStatus{
 					PodIP: "0.0.0.0",
+					Phase: corev1.PodRunning,
 				},
 			},
 		},
@@ -292,6 +296,7 @@ func TestCheckSentinelNumberInMemoryNumberMismatch(t *testing.T) {
 			{
 				Status: corev1.PodStatus{
 					PodIP: "0.0.0.0",
+					Phase: corev1.PodRunning,
 				},
 			},
 		},
@@ -318,6 +323,7 @@ func TestCheckSentinelNumberInMemory(t *testing.T) {
 			{
 				Status: corev1.PodStatus{
 					PodIP: "0.0.0.0",
+					Phase: corev1.PodRunning,
 				},
 			},
 		},
@@ -359,6 +365,7 @@ func TestCheckSentinelSlavesNumberInMemoryGetNumberSentinelSlavesInMemoryError(t
 			{
 				Status: corev1.PodStatus{
 					PodIP: "0.0.0.0",
+					Phase: corev1.PodRunning,
 				},
 			},
 		},
@@ -385,6 +392,7 @@ func TestCheckSentinelSlavesNumberInMemoryReplicasMismatch(t *testing.T) {
 			{
 				Status: corev1.PodStatus{
 					PodIP: "0.0.0.0",
+					Phase: corev1.PodRunning,
 				},
 			},
 		},
@@ -411,6 +419,7 @@ func TestCheckSentinelSlavesNumberInMemory(t *testing.T) {
 			{
 				Status: corev1.PodStatus{
 					PodIP: "0.0.0.0",
+					Phase: corev1.PodRunning,
 				},
 			},
 		},
@@ -491,6 +500,7 @@ func TestGetMasterIPIsMasterError(t *testing.T) {
 			{
 				Status: corev1.PodStatus{
 					PodIP: "0.0.0.0",
+					Phase: corev1.PodRunning,
 				},
 			},
 		},
@@ -517,11 +527,13 @@ func TestGetMasterIPMultipleMastersError(t *testing.T) {
 			{
 				Status: corev1.PodStatus{
 					PodIP: "0.0.0.0",
+					Phase: corev1.PodRunning,
 				},
 			},
 			{
 				Status: corev1.PodStatus{
 					PodIP: "1.1.1.1",
+					Phase: corev1.PodRunning,
 				},
 			},
 		},
@@ -549,11 +561,13 @@ func TestGetMasterIP(t *testing.T) {
 			{
 				Status: corev1.PodStatus{
 					PodIP: "0.0.0.0",
+					Phase: corev1.PodRunning,
 				},
 			},
 			{
 				Status: corev1.PodStatus{
 					PodIP: "1.1.1.1",
+					Phase: corev1.PodRunning,
 				},
 			},
 		},
@@ -597,6 +611,7 @@ func TestGetNumberMastersIsMasterError(t *testing.T) {
 			{
 				Status: corev1.PodStatus{
 					PodIP: "0.0.0.0",
+					Phase: corev1.PodRunning,
 				},
 			},
 		},
@@ -623,11 +638,13 @@ func TestGetNumberMasters(t *testing.T) {
 			{
 				Status: corev1.PodStatus{
 					PodIP: "0.0.0.0",
+					Phase: corev1.PodRunning,
 				},
 			},
 			{
 				Status: corev1.PodStatus{
 					PodIP: "1.1.1.1",
+					Phase: corev1.PodRunning,
 				},
 			},
 		},
@@ -656,11 +673,13 @@ func TestGetNumberMastersTwo(t *testing.T) {
 			{
 				Status: corev1.PodStatus{
 					PodIP: "0.0.0.0",
+					Phase: corev1.PodRunning,
 				},
 			},
 			{
 				Status: corev1.PodStatus{
 					PodIP: "1.1.1.1",
+					Phase: corev1.PodRunning,
 				},
 			},
 		},

--- a/operator/redisfailover/service/generator.go
+++ b/operator/redisfailover/service/generator.go
@@ -19,7 +19,7 @@ const (
 	redisShutdownConfigurationVolumeName = "redis-shutdown-config"
 	redisStorageVolumeName               = "redis-data"
 
-	graceTime = 60
+	graceTime = 30
 )
 
 func generateSentinelService(rf *redisfailoverv1alpha2.RedisFailover, labels map[string]string, ownerRefs []metav1.OwnerReference) *corev1.Service {

--- a/operator/redisfailover/service/heal.go
+++ b/operator/redisfailover/service/heal.go
@@ -12,6 +12,7 @@ import (
 
 // RedisFailoverHeal defines the interface able to fix the problems on the redis failovers
 type RedisFailoverHeal interface {
+	MakeMaster(ip string) error
 	SetRandomMaster(rFailover *redisfailoverv1alpha2.RedisFailover) error
 	SetMasterOnAll(masterIP string, rFailover *redisfailoverv1alpha2.RedisFailover) error
 	NewSentinelMonitor(ip string, monitor string, rFailover *redisfailoverv1alpha2.RedisFailover) error
@@ -34,6 +35,10 @@ func NewRedisFailoverHealer(k8sService k8s.Services, redisClient redis.Client, l
 		redisClient: redisClient,
 		logger:      logger,
 	}
+}
+
+func (r *RedisFailoverHealer) MakeMaster(ip string) error {
+	return r.redisClient.MakeMaster(ip)
 }
 
 // SetRandomMaster puts all redis to the same master, choosen by order


### PR DESCRIPTION
Changes proposed on the PR:
- Checks only pods running.
- Speedup starting time by making master if only one redis node.
- When forcing a new master, use the oldest pod (has more probability of having more data).
- Reduce the delay for probes on redis to 30s
- Bump version to 0.5.4