### PR TITLE
Use our created ServiceAccount

### DIFF
--- a/example/operator/all-redis-operator-resources.yaml
+++ b/example/operator/all-redis-operator-resources.yaml
@@ -16,6 +16,7 @@ spec:
       labels:
         app: redisoperator
     spec:
+      serviceAccountName: redisoperator
       containers:
       - image: quay.io/spotahome/redis-operator:latest
         imagePullPolicy: IfNotPresent

--- a/example/operator/all-redis-operator-resources.yaml
+++ b/example/operator/all-redis-operator-resources.yaml
@@ -29,6 +29,7 @@ spec:
             cpu: 10m
             memory: 50Mi
       restartPolicy: Always
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -41,6 +42,7 @@ subjects:
 - kind: ServiceAccount
   name: redisoperator
   namespace: default
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -81,6 +83,7 @@ rules:
     - poddisruptionbudgets
   verbs:
     - "*"
+---
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/example/operator/operator.yaml
+++ b/example/operator/operator.yaml
@@ -16,6 +16,7 @@ spec:
       labels:
         app: redisoperator
     spec:
+      serviceAccountName: redisoperator
       containers:
       - image: quay.io/spotahome/redis-operator:latest
         imagePullPolicy: IfNotPresent


### PR DESCRIPTION
If not precised, the operator will use the namespace default ServiceAccount, which does not have any permissions for CRD etc…