### PR TITLE
Add IMAGE_NAME and REPO_SERVER variables to be set into Makefile.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,10 +4,11 @@ VERSION := 0.5.4
 SERVICE_NAME := redis-operator
 
 # Docker image name for this project
-IMAGE_NAME := spotahome/$(SERVICE_NAME)
+IMAGE_NAME ?= spotahome
 
 # Repository url for this project
-REPOSITORY := quay.io/$(IMAGE_NAME)
+REPO_SERVER ?= quay.io
+REPOSITORY := $(REPO_SERVER)/$(IMAGE_NAME)/$(SERVICE_NAME)
 
 # Shell to use for running scripts
 SHELL := $(shell which bash)

--- a/docs/development.md
+++ b/docs/development.md
@@ -20,7 +20,7 @@
 * **scripts**: scripts used to build and run the app.
 
 ## Make development commands
-You can do the following commands with make:
+You can do the following commands with `make`:
 * Build the development container.
 `make docker-build`
 * Generate mocks.
@@ -41,3 +41,8 @@ You can do the following commands with make:
 `make update-deps`
 * Build the app image.
 `make image`
+
+If a different Docker image and its repository needs to be used, it can be specified on each `make` call with the `IMAGE_NAME` and `REPO_SERVER` variables, for example:
+```
+make build IMAGE_NAME=my_image REPO_SERVER=my_repository_server
+```


### PR DESCRIPTION
Changes proposed on the PR:
- Add `IMAGE_NAME` and `REPO_SERVER` variables to be set at `make` calls if a developer needs to use a different Docker image and its repo, the defaults values remains.
- The developer documentation is updated accordingly.

Signed-off-by: Morales Quispe, Marcela <marcela.morales.quispe@intel.com>
