### PR TITLE
Bump memory to help CVE-patched runc start containers

### DIFF
--- a/operator/redisfailover/service/generator.go
+++ b/operator/redisfailover/service/generator.go
@@ -317,11 +317,11 @@ func generateSentinelDeployment(rf *redisfailoverv1alpha2.RedisFailover, labels 
 							Resources: corev1.ResourceRequirements{
 								Limits: corev1.ResourceList{
 									corev1.ResourceCPU:    resource.MustParse("10m"),
-									corev1.ResourceMemory: resource.MustParse("10Mi"),
+									corev1.ResourceMemory: resource.MustParse("16Mi"),
 								},
 								Requests: corev1.ResourceList{
 									corev1.ResourceCPU:    resource.MustParse("10m"),
-									corev1.ResourceMemory: resource.MustParse("10Mi"),
+									corev1.ResourceMemory: resource.MustParse("16Mi"),
 								},
 							},
 						},


### PR DESCRIPTION
Initcontainers fail with message : ```message: 'OCI runtime create failed: container_linux.go:348: starting container
          process caused "process_linux.go:402: container init caused \"process_linux.go:367:
          setting cgroup config for procHooks process caused \\\"failed to write 10485760
          to memory.limit_in_bytes: write /sys/fs/cgroup/memory/kubepods/burstable/pod8b46ac66-3396-11e9-8868-06008508f8fe/312653fa8dac427416a12f4d3398ced9782229867907f8179697e8858f7a401d/memory.limit_in_bytes:
          device or resource busy\\\"\"": unknown'
        reason: ContainerCannotRun```