### PR TITLE
Add steps for pmem volume mount to be properly configured.

### DIFF
--- a/example/redisfailover/pmem.yaml
+++ b/example/redisfailover/pmem.yaml
@@ -1,0 +1,26 @@
+apiVersion: storage.spotahome.com/v1alpha2
+kind: RedisFailover
+metadata:
+  name: redisfailover-pmem
+spec:
+  sentinel:
+    replicas: 3
+    customConfig:
+      - "protected-mode no"
+  redis:
+    replicas: 3
+    customConfig:
+      - "protected-mode no"
+    image: redis_pmem			# From https://github.com/pmem/pmem-redis (needs to be built and uploaded to a repository to be used)
+    version: latest
+    storage:
+      persistentVolumeClaim:
+        metadata:
+          name: redisfailover-pmem-data
+        spec:
+          accessModes:
+          - ReadWriteOnce
+          resources:
+            requests:
+              storage: 100Mi
+          storageClassName: pmem-csi-sc


### PR DESCRIPTION
Signed-off-by: Morales Quispe, Marcela <marcela.morales.quispe@intel.com>

Fixes #111  .

Changes proposed on the PR:
- Extra configuration added in order to use `pmem-csi-sc` storage class: specific path where to write persistent data and `protected-mode` configuration for redis and sentinel instances.

**Deployments used:** 
  * `example/redisfailover/pmem.yaml`
  * `example/redisfailover/persistent-storage.yaml` (with `storage:300Mi` for persistentVolumeClaim)

**Logs from tests:**
```
$ kubectl get sc
NAME                        PROVISIONER          AGE
pmem-csi-sc                 pmem-csi             93m
rook-ceph-block (default)   ceph.rook.io/block   104m

$  kubectl get po
NAME                                            READY   STATUS    RESTARTS   AGE
pmem-csi-49t57                                  2/2     Running   1          93m
pmem-csi-controller-0                           4/4     Running   0          93m
redisfailover-redisoperator-85f6f54988-tltdd    1/1     Running   1          25m
rfr-redisfailover-persistent-0                  1/1     Running   0          19m
rfr-redisfailover-persistent-1                  1/1     Running   0          18m
rfr-redisfailover-persistent-2                  1/1     Running   0          17m
rfr-redisfailover-pmem-0                        1/1     Running   0          24m
rfr-redisfailover-pmem-1                        1/1     Running   0          24m
rfr-redisfailover-pmem-2                        1/1     Running   0          23m
rfs-redisfailover-persistent-778455759b-hh49h   1/1     Running   0          19m
rfs-redisfailover-persistent-778455759b-hpp25   1/1     Running   0          19m
rfs-redisfailover-persistent-778455759b-w6hmz   1/1     Running   0          19m
rfs-redisfailover-pmem-85f8764db-nhwlg          1/1     Running   0          24m
rfs-redisfailover-pmem-85f8764db-s6rx5          1/1     Running   0          24m
rfs-redisfailover-pmem-85f8764db-wpjvx          1/1     Running   0          24m
``` 
Logs from resources 
[logs.txt](https://github.com/spotahome/redis-operator/files/2896418/logs.txt)
