### PR TITLE
Check for nil pointer when getting minimum redis pod time

### DIFF
--- a/operator/redisfailover/service/check.go
+++ b/operator/redisfailover/service/check.go
@@ -212,6 +212,9 @@ func (r *RedisFailoverChecker) GetMinimumRedisPodTime(rf *redisfailoverv1alpha2.
 		return minTime, err
 	}
 	for _, redisNode := range rps.Items {
+		if redisNode.Status.StartTime == nil {
+			continue
+		}
 		start := redisNode.Status.StartTime.Round(time.Second)
 		alive := time.Now().Sub(start)
 		r.logger.Debugf("Pod %s has been alive for %.f seconds", redisNode.Status.PodIP, alive.Seconds())


### PR DESCRIPTION
Fixes #122

Changes proposed on the PR:
- Check if pod has `StartTime` to prevent panic of nil pointer