### PR TITLE
Add example of using user-defined image

### DIFF
--- a/example/redisfailover/custom-image.yaml
+++ b/example/redisfailover/custom-image.yaml
@@ -1,0 +1,11 @@
+apiVersion: storage.spotahome.com/v1alpha2
+kind: RedisFailover
+metadata:
+  name: redisfailover
+spec:
+  sentinel:
+    replicas: 3
+  redis:
+    replicas: 3
+    image: redis
+    version: 5.0-alpine


### PR DESCRIPTION
Show how to use a specific image and version for the redis failover.

Adds context to explain #134 