### PR TITLE
Add Customisable PodSecurityContext

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ This behavior is configurable, creating a configmap and indicating to use it. An
 
 ### Custom SecurityContext
 By default Kubernetes will run containers as the user specified in the Dockerfile (or the root user if not specified), this is not always desirable.
-If you need the containers to run as a specific user (e.g. you dont allow containers to run as root) then you can specify a custom `securityContext` in the
+If you need the containers to run as a specific user (or provide any other PodSecurityContext options) then you can specify a custom `securityContext` in the
 `redisfailover` object.  See the [SecurityContext example file](example/redisfailover/security-context.yaml) for an example. Keys available under securityContext are detailed [here](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.14/#podsecuritycontext-v1-core)
 
 ### Custom command

--- a/README.md
+++ b/README.md
@@ -147,6 +147,11 @@ This behavior is configurable, creating a configmap and indicating to use it. An
 
 **Important**: the configmap has to be in the same namespace. The configmap has to have a `shutdown.sh` data, containing the script.
 
+### Custom SecurityContext
+By default Kubernetes will run containers as the user specified in the Dockerfile (or the root user if not specified), this is not always desirable.
+If you need the containers to run as a specific user (e.g. you dont allow containers to run as root) then you can specify a custom `securityContext` in the
+`redisfailover` object.  See the Custom SecurityContext [example file](example/redisfailover/security-context.yaml for an example. Keys available under securityContext are detailed [here](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.14/#podsecuritycontext-v1-core)
+
 ### Custom command
 
 By default, redis and sentinel will be called with de basic command, giving the configuration file:

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ This behavior is configurable, creating a configmap and indicating to use it. An
 ### Custom SecurityContext
 By default Kubernetes will run containers as the user specified in the Dockerfile (or the root user if not specified), this is not always desirable.
 If you need the containers to run as a specific user (e.g. you dont allow containers to run as root) then you can specify a custom `securityContext` in the
-`redisfailover` object.  See the [SecurityContext example file](example/redisfailover/security-context.yam0l) for an example. Keys available under securityContext are detailed [here](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.14/#podsecuritycontext-v1-core)
+`redisfailover` object.  See the [SecurityContext example file](example/redisfailover/security-context.yaml) for an example. Keys available under securityContext are detailed [here](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.14/#podsecuritycontext-v1-core)
 
 ### Custom command
 

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ This behavior is configurable, creating a configmap and indicating to use it. An
 ### Custom SecurityContext
 By default Kubernetes will run containers as the user specified in the Dockerfile (or the root user if not specified), this is not always desirable.
 If you need the containers to run as a specific user (e.g. you dont allow containers to run as root) then you can specify a custom `securityContext` in the
-`redisfailover` object.  See the Custom SecurityContext [example file](example/redisfailover/security-context.yaml for an example. Keys available under securityContext are detailed [here](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.14/#podsecuritycontext-v1-core)
+`redisfailover` object.  See the [SecurityContext example file](example/redisfailover/security-context.yam0l) for an example. Keys available under securityContext are detailed [here](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.14/#podsecuritycontext-v1-core)
 
 ### Custom command
 

--- a/api/redisfailover/v1alpha2/types.go
+++ b/api/redisfailover/v1alpha2/types.go
@@ -31,6 +31,9 @@ type RedisFailoverSpec struct {
 	// NodeAffinity defines the rules for scheduling the Redis and Sentinel
 	// nodes
 	NodeAffinity *corev1.NodeAffinity `json:"nodeAffinity,omitempty"`
+	
+	// SecurityContext defines which user and group the Sentinel and Redis containers run as
+	SecurityContext *corev1.PodSecurityContext `json:"securityContext,omitempty"`
 
 	//Tolerations provides a way to schedule Pods on Tainted Nodes
 	Tolerations []corev1.Toleration `json:"tolerations,omitempty"`

--- a/example/redisfailover/security-context.yaml
+++ b/example/redisfailover/security-context.yaml
@@ -1,0 +1,13 @@
+apiVersion: storage.spotahome.com/v1alpha2
+kind: RedisFailover
+metadata:
+  name: redisfailover
+spec:
+  sentinel:
+    replicas: 3
+  redis:
+    replicas: 3
+  securityContext:
+    runAsUser: 1000
+    runAsGroup: 1000
+    fsGroup: 1000

--- a/operator/redisfailover/service/generator.go
+++ b/operator/redisfailover/service/generator.go
@@ -191,6 +191,7 @@ func generateRedisStatefulSet(rf *redisfailoverv1alpha2.RedisFailover, labels ma
 						PodAntiAffinity: createPodAntiAffinity(rf.Spec.HardAntiAffinity, labels),
 					},
 					Tolerations: rf.Spec.Tolerations,
+					SecurityContext: rf.Spec.SecurityContext,
 					Containers: []corev1.Container{
 						{
 							Name:            "redis",

--- a/operator/redisfailover/service/generator.go
+++ b/operator/redisfailover/service/generator.go
@@ -298,6 +298,7 @@ func generateSentinelDeployment(rf *redisfailoverv1alpha2.RedisFailover, labels 
 						PodAntiAffinity: createPodAntiAffinity(rf.Spec.HardAntiAffinity, labels),
 					},
 					Tolerations: rf.Spec.Tolerations,
+					SecurityContext: rf.Spec.SecurityContext,
 					InitContainers: []corev1.Container{
 						{
 							Name:            "sentinel-config-copy",


### PR DESCRIPTION
Hey,

Thanks for the operator.  We have a specific requirement that containers never run as root within our clusters.  As a result I had added the ability to provide PodSecurityContexts to the redisFailover objects that are applied to redis and the sentinel pods created by the operator.

I've updated the documentation and provided an example.

Let me know what you think.

Cheers,
Adam