### PR TITLE
Update storageClassName  used at pmem.yaml example.

### DIFF
--- a/example/redisfailover/pmem.yaml
+++ b/example/redisfailover/pmem.yaml
@@ -35,4 +35,4 @@ spec:
           resources:
             requests:
               storage: 100Mi
-          storageClassName: pmem-csi-sc		# From https://github.com/intel/pmem-CSI
+          storageClassName: pmem-csi-sc-ext4	# From https://github.com/intel/pmem-CSI


### PR DESCRIPTION
The pmem-csi-sc StorageClass is no longer available at pmem-CSI repo.

Signed-off-by: Morales Quispe, Marcela <marcela.morales.quispe@intel.com>