### PR TITLE
Change groupname

### DIFF
--- a/api/redisfailover/register.go
+++ b/api/redisfailover/register.go
@@ -1,5 +1,5 @@
 package redisfailover
 
 const (
-	GroupName = "storage.spotahome.com"
+	GroupName = "databases.spotahome.com"
 )

--- a/api/redisfailover/v1/doc.go
+++ b/api/redisfailover/v1/doc.go
@@ -1,5 +1,5 @@
 // +k8s:deepcopy-gen=package
 
 // Package v1 is the v1 version of the API.
-// +groupName=storage.spotahome.com
+// +groupName=databases.spotahome.com
 package v1

--- a/charts/redisoperator/Chart.yaml
+++ b/charts/redisoperator/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for the Spotahome Redis Operator
 name: redisoperator
-version: 2.4.1
+version: 3.0.0

--- a/charts/redisoperator/templates/_functions.tpl
+++ b/charts/redisoperator/templates/_functions.tpl
@@ -1,14 +1,13 @@
 {{/* Build the Spotahome standard labels */}}
 {{- define "common-labels" -}}
-app: {{ .Chart.Name | quote }}
-team: {{ .Values.team | quote }}
+app.kubernetes.io/name: {{ .Chart.Name | quote }}
 {{- end }}
 
 {{- define "helm-labels" -}}
 {{ include "common-labels" . }}
-chart: {{ printf "%s-%s" .Chart.Name .Chart.Version | quote }}
-release: {{ .Release.Name | quote }}
-heritage: {{ .Release.Service | quote }}
+helm.sh/chart: {{ printf "%s-%s" .Chart.Name .Chart.Version | quote }}
+app.kubernetes.io/instance: {{ .Release.Name | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
 {{- end }}
 
 {{/* Build wide-used variables the application */}}

--- a/charts/redisoperator/templates/deployment.yaml
+++ b/charts/redisoperator/templates/deployment.yaml
@@ -1,20 +1,20 @@
-apiVersion: {{ .Values.apiVersion }}
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "name" . | quote }}
   labels:
-    component: app
+    app.kubernetes.io/component: app
 {{ include "helm-labels" . | indent 4 }}
 spec:
   replicas: 1
   selector:
     matchLabels:
-      component: app
+      app.kubernetes.io/component: app
 {{ include "common-labels" . | indent 6 }}
   template:
     metadata:
       labels:
-        component: app
+        app.kubernetes.io/component: app
 {{ include "common-labels" . | indent 8 }}
 {{- if .Values.podAnnotations }}
       annotations:

--- a/charts/redisoperator/templates/rbac.yaml
+++ b/charts/redisoperator/templates/rbac.yaml
@@ -16,7 +16,7 @@ metadata:
 {{ include "common-labels" . | indent 4 }}
 rules:
   - apiGroups:
-      - storage.spotahome.com
+      - databases.spotahome.com
     resources:
       - redisfailovers
     verbs:

--- a/charts/redisoperator/values.yaml
+++ b/charts/redisoperator/values.yaml
@@ -1,9 +1,7 @@
-replicaCount: 1
-apiVersion: apps/v1
 image: quay.io/spotahome/redis-operator
 tag: latest
+replicas: 1
 pullPolicy: Always
-team: devops
 containerName: redisoperator
 podAnnotations: {}
 resources:

--- a/client/k8s/clientset/versioned/clientset.go
+++ b/client/k8s/clientset/versioned/clientset.go
@@ -19,7 +19,7 @@ limitations under the License.
 package versioned
 
 import (
-	storagev1 "github.com/spotahome/redis-operator/client/k8s/clientset/versioned/typed/redisfailover/v1"
+	databasesv1 "github.com/spotahome/redis-operator/client/k8s/clientset/versioned/typed/redisfailover/v1"
 	discovery "k8s.io/client-go/discovery"
 	rest "k8s.io/client-go/rest"
 	flowcontrol "k8s.io/client-go/util/flowcontrol"
@@ -27,27 +27,27 @@ import (
 
 type Interface interface {
 	Discovery() discovery.DiscoveryInterface
-	StorageV1() storagev1.StorageV1Interface
+	DatabasesV1() databasesv1.DatabasesV1Interface
 	// Deprecated: please explicitly pick a version if possible.
-	Storage() storagev1.StorageV1Interface
+	Databases() databasesv1.DatabasesV1Interface
 }
 
 // Clientset contains the clients for groups. Each group has exactly one
 // version included in a Clientset.
 type Clientset struct {
 	*discovery.DiscoveryClient
-	storageV1 *storagev1.StorageV1Client
+	databasesV1 *databasesv1.DatabasesV1Client
 }
 
-// StorageV1 retrieves the StorageV1Client
-func (c *Clientset) StorageV1() storagev1.StorageV1Interface {
-	return c.storageV1
+// DatabasesV1 retrieves the DatabasesV1Client
+func (c *Clientset) DatabasesV1() databasesv1.DatabasesV1Interface {
+	return c.databasesV1
 }
 
-// Deprecated: Storage retrieves the default version of StorageClient.
+// Deprecated: Databases retrieves the default version of DatabasesClient.
 // Please explicitly pick a version.
-func (c *Clientset) Storage() storagev1.StorageV1Interface {
-	return c.storageV1
+func (c *Clientset) Databases() databasesv1.DatabasesV1Interface {
+	return c.databasesV1
 }
 
 // Discovery retrieves the DiscoveryClient
@@ -66,7 +66,7 @@ func NewForConfig(c *rest.Config) (*Clientset, error) {
 	}
 	var cs Clientset
 	var err error
-	cs.storageV1, err = storagev1.NewForConfig(&configShallowCopy)
+	cs.databasesV1, err = databasesv1.NewForConfig(&configShallowCopy)
 	if err != nil {
 		return nil, err
 	}
@@ -82,7 +82,7 @@ func NewForConfig(c *rest.Config) (*Clientset, error) {
 // panics if there is an error in the config.
 func NewForConfigOrDie(c *rest.Config) *Clientset {
 	var cs Clientset
-	cs.storageV1 = storagev1.NewForConfigOrDie(c)
+	cs.databasesV1 = databasesv1.NewForConfigOrDie(c)
 
 	cs.DiscoveryClient = discovery.NewDiscoveryClientForConfigOrDie(c)
 	return &cs
@@ -91,7 +91,7 @@ func NewForConfigOrDie(c *rest.Config) *Clientset {
 // New creates a new Clientset for the given RESTClient.
 func New(c rest.Interface) *Clientset {
 	var cs Clientset
-	cs.storageV1 = storagev1.New(c)
+	cs.databasesV1 = databasesv1.New(c)
 
 	cs.DiscoveryClient = discovery.NewDiscoveryClient(c)
 	return &cs

--- a/client/k8s/clientset/versioned/fake/clientset_generated.go
+++ b/client/k8s/clientset/versioned/fake/clientset_generated.go
@@ -20,8 +20,8 @@ package fake
 
 import (
 	clientset "github.com/spotahome/redis-operator/client/k8s/clientset/versioned"
-	storagev1 "github.com/spotahome/redis-operator/client/k8s/clientset/versioned/typed/redisfailover/v1"
-	fakestoragev1 "github.com/spotahome/redis-operator/client/k8s/clientset/versioned/typed/redisfailover/v1/fake"
+	databasesv1 "github.com/spotahome/redis-operator/client/k8s/clientset/versioned/typed/redisfailover/v1"
+	fakedatabasesv1 "github.com/spotahome/redis-operator/client/k8s/clientset/versioned/typed/redisfailover/v1/fake"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/discovery"
@@ -71,12 +71,12 @@ func (c *Clientset) Discovery() discovery.DiscoveryInterface {
 
 var _ clientset.Interface = &Clientset{}
 
-// StorageV1 retrieves the StorageV1Client
-func (c *Clientset) StorageV1() storagev1.StorageV1Interface {
-	return &fakestoragev1.FakeStorageV1{Fake: &c.Fake}
+// DatabasesV1 retrieves the DatabasesV1Client
+func (c *Clientset) DatabasesV1() databasesv1.DatabasesV1Interface {
+	return &fakedatabasesv1.FakeDatabasesV1{Fake: &c.Fake}
 }
 
-// Storage retrieves the StorageV1Client
-func (c *Clientset) Storage() storagev1.StorageV1Interface {
-	return &fakestoragev1.FakeStorageV1{Fake: &c.Fake}
+// Databases retrieves the DatabasesV1Client
+func (c *Clientset) Databases() databasesv1.DatabasesV1Interface {
+	return &fakedatabasesv1.FakeDatabasesV1{Fake: &c.Fake}
 }

--- a/client/k8s/clientset/versioned/fake/register.go
+++ b/client/k8s/clientset/versioned/fake/register.go
@@ -19,7 +19,7 @@ limitations under the License.
 package fake
 
 import (
-	storagev1 "github.com/spotahome/redis-operator/api/redisfailover/v1"
+	databasesv1 "github.com/spotahome/redis-operator/api/redisfailover/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"
@@ -50,5 +50,5 @@ func init() {
 // After this, RawExtensions in Kubernetes types will serialize kube-aggregator types
 // correctly.
 func AddToScheme(scheme *runtime.Scheme) {
-	storagev1.AddToScheme(scheme)
+	databasesv1.AddToScheme(scheme)
 }

--- a/client/k8s/clientset/versioned/scheme/register.go
+++ b/client/k8s/clientset/versioned/scheme/register.go
@@ -19,7 +19,7 @@ limitations under the License.
 package scheme
 
 import (
-	storagev1 "github.com/spotahome/redis-operator/api/redisfailover/v1"
+	databasesv1 "github.com/spotahome/redis-operator/api/redisfailover/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"
@@ -50,5 +50,5 @@ func init() {
 // After this, RawExtensions in Kubernetes types will serialize kube-aggregator types
 // correctly.
 func AddToScheme(scheme *runtime.Scheme) {
-	storagev1.AddToScheme(scheme)
+	databasesv1.AddToScheme(scheme)
 }

--- a/client/k8s/clientset/versioned/typed/redisfailover/v1/fake/fake_redisfailover.go
+++ b/client/k8s/clientset/versioned/typed/redisfailover/v1/fake/fake_redisfailover.go
@@ -30,13 +30,13 @@ import (
 
 // FakeRedisFailovers implements RedisFailoverInterface
 type FakeRedisFailovers struct {
-	Fake *FakeStorageV1
+	Fake *FakeDatabasesV1
 	ns   string
 }
 
-var redisfailoversResource = schema.GroupVersionResource{Group: "storage.spotahome.com", Version: "v1", Resource: "redisfailovers"}
+var redisfailoversResource = schema.GroupVersionResource{Group: "databases.spotahome.com", Version: "v1", Resource: "redisfailovers"}
 
-var redisfailoversKind = schema.GroupVersionKind{Group: "storage.spotahome.com", Version: "v1", Kind: "RedisFailover"}
+var redisfailoversKind = schema.GroupVersionKind{Group: "databases.spotahome.com", Version: "v1", Kind: "RedisFailover"}
 
 // Get takes name of the redisFailover, and returns the corresponding redisFailover object, and an error if there is any.
 func (c *FakeRedisFailovers) Get(name string, options v1.GetOptions) (result *redisfailover_v1.RedisFailover, err error) {

--- a/client/k8s/clientset/versioned/typed/redisfailover/v1/fake/fake_redisfailover_client.go
+++ b/client/k8s/clientset/versioned/typed/redisfailover/v1/fake/fake_redisfailover_client.go
@@ -24,17 +24,17 @@ import (
 	testing "k8s.io/client-go/testing"
 )
 
-type FakeStorageV1 struct {
+type FakeDatabasesV1 struct {
 	*testing.Fake
 }
 
-func (c *FakeStorageV1) RedisFailovers(namespace string) v1.RedisFailoverInterface {
+func (c *FakeDatabasesV1) RedisFailovers(namespace string) v1.RedisFailoverInterface {
 	return &FakeRedisFailovers{c, namespace}
 }
 
 // RESTClient returns a RESTClient that is used to communicate
 // with API server by this client implementation.
-func (c *FakeStorageV1) RESTClient() rest.Interface {
+func (c *FakeDatabasesV1) RESTClient() rest.Interface {
 	var ret *rest.RESTClient
 	return ret
 }

--- a/client/k8s/clientset/versioned/typed/redisfailover/v1/redisfailover.go
+++ b/client/k8s/clientset/versioned/typed/redisfailover/v1/redisfailover.go
@@ -53,7 +53,7 @@ type redisFailovers struct {
 }
 
 // newRedisFailovers returns a RedisFailovers
-func newRedisFailovers(c *StorageV1Client, namespace string) *redisFailovers {
+func newRedisFailovers(c *DatabasesV1Client, namespace string) *redisFailovers {
 	return &redisFailovers{
 		client: c.RESTClient(),
 		ns:     namespace,

--- a/client/k8s/clientset/versioned/typed/redisfailover/v1/redisfailover_client.go
+++ b/client/k8s/clientset/versioned/typed/redisfailover/v1/redisfailover_client.go
@@ -25,22 +25,22 @@ import (
 	rest "k8s.io/client-go/rest"
 )
 
-type StorageV1Interface interface {
+type DatabasesV1Interface interface {
 	RESTClient() rest.Interface
 	RedisFailoversGetter
 }
 
-// StorageV1Client is used to interact with features provided by the storage.spotahome.com group.
-type StorageV1Client struct {
+// DatabasesV1Client is used to interact with features provided by the databases.spotahome.com group.
+type DatabasesV1Client struct {
 	restClient rest.Interface
 }
 
-func (c *StorageV1Client) RedisFailovers(namespace string) RedisFailoverInterface {
+func (c *DatabasesV1Client) RedisFailovers(namespace string) RedisFailoverInterface {
 	return newRedisFailovers(c, namespace)
 }
 
-// NewForConfig creates a new StorageV1Client for the given config.
-func NewForConfig(c *rest.Config) (*StorageV1Client, error) {
+// NewForConfig creates a new DatabasesV1Client for the given config.
+func NewForConfig(c *rest.Config) (*DatabasesV1Client, error) {
 	config := *c
 	if err := setConfigDefaults(&config); err != nil {
 		return nil, err
@@ -49,12 +49,12 @@ func NewForConfig(c *rest.Config) (*StorageV1Client, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &StorageV1Client{client}, nil
+	return &DatabasesV1Client{client}, nil
 }
 
-// NewForConfigOrDie creates a new StorageV1Client for the given config and
+// NewForConfigOrDie creates a new DatabasesV1Client for the given config and
 // panics if there is an error in the config.
-func NewForConfigOrDie(c *rest.Config) *StorageV1Client {
+func NewForConfigOrDie(c *rest.Config) *DatabasesV1Client {
 	client, err := NewForConfig(c)
 	if err != nil {
 		panic(err)
@@ -62,9 +62,9 @@ func NewForConfigOrDie(c *rest.Config) *StorageV1Client {
 	return client
 }
 
-// New creates a new StorageV1Client for the given RESTClient.
-func New(c rest.Interface) *StorageV1Client {
-	return &StorageV1Client{c}
+// New creates a new DatabasesV1Client for the given RESTClient.
+func New(c rest.Interface) *DatabasesV1Client {
+	return &DatabasesV1Client{c}
 }
 
 func setConfigDefaults(config *rest.Config) error {
@@ -82,7 +82,7 @@ func setConfigDefaults(config *rest.Config) error {
 
 // RESTClient returns a RESTClient that is used to communicate
 // with API server by this client implementation.
-func (c *StorageV1Client) RESTClient() rest.Interface {
+func (c *DatabasesV1Client) RESTClient() rest.Interface {
 	if c == nil {
 		return nil
 	}

--- a/service/k8s/redisfailover.go
+++ b/service/k8s/redisfailover.go
@@ -34,10 +34,10 @@ func NewRedisFailoverService(crdcli redisfailoverclientset.Interface, logger log
 
 // ListRedisFailovers satisfies redisfailover.Service interface.
 func (r *RedisFailoverService) ListRedisFailovers(namespace string, opts metav1.ListOptions) (*redisfailoverv1.RedisFailoverList, error) {
-	return r.crdClient.StorageV1().RedisFailovers(namespace).List(opts)
+	return r.crdClient.DatabasesV1().RedisFailovers(namespace).List(opts)
 }
 
 // WatchRedisFailovers satisfies redisfailover.Service interface.
 func (r *RedisFailoverService) WatchRedisFailovers(namespace string, opts metav1.ListOptions) (watch.Interface, error) {
-	return r.crdClient.StorageV1().RedisFailovers(namespace).Watch(opts)
+	return r.crdClient.DatabasesV1().RedisFailovers(namespace).Watch(opts)
 }

--- a/test/integration/redisfailover/creation_test.go
+++ b/test/integration/redisfailover/creation_test.go
@@ -148,8 +148,8 @@ func (c *clients) testCRCreation(t *testing.T) {
 		},
 	}
 
-	c.rfClient.StorageV1().RedisFailovers(namespace).Create(toCreate)
-	gotRF, err := c.rfClient.StorageV1().RedisFailovers(namespace).Get(name, metav1.GetOptions{})
+	c.rfClient.DatabasesV1().RedisFailovers(namespace).Create(toCreate)
+	gotRF, err := c.rfClient.DatabasesV1().RedisFailovers(namespace).Get(name, metav1.GetOptions{})
 
 	assert.NoError(err)
 	assert.Equal(toCreate.Spec, gotRF.Spec)


### PR DESCRIPTION
Rename the groupname of the CRD to `databases.spotahome.com` because it's not possible to have different specs for each api version in kubernetes prior to version 1.13 and it's important to allow the usage of the operator in previous versions.

Also, update the chart rbac and simplify.