### PR TITLE
imagePullSecrets added

### DIFF
--- a/api/redisfailover/v1/types.go
+++ b/api/redisfailover/v1/types.go
@@ -33,6 +33,7 @@ type RedisSettings struct {
 	Exporter          RedisExporter               `json:"exporter,omitempty"`
 	Affinity          *corev1.Affinity            `json:"affinity,omitempty"`
 	SecurityContext   *corev1.PodSecurityContext  `json:"securityContext,omitempty"`
+	ImagePullSecrets  []corev1.LocalObjectReference`json:"imagePullSecrets,omitempty"`
 	Tolerations       []corev1.Toleration         `json:"tolerations,omitempty"`
 }
 
@@ -45,6 +46,7 @@ type SentinelSettings struct {
 	Command         []string                    `json:"command,omitempty"`
 	Affinity        *corev1.Affinity            `json:"affinity,omitempty"`
 	SecurityContext *corev1.PodSecurityContext  `json:"securityContext,omitempty"`
+	ImagePullSecrets[]corev1.LocalObjectReference`json:"imagePullSecrets,omitempty"`
 	Tolerations     []corev1.Toleration         `json:"tolerations,omitempty"`
 }
 

--- a/operator/redisfailover/service/generator.go
+++ b/operator/redisfailover/service/generator.go
@@ -189,6 +189,7 @@ func generateRedisStatefulSet(rf *redisfailoverv1.RedisFailover, labels map[stri
 					Affinity:        getAffinity(rf.Spec.Redis.Affinity, labels),
 					Tolerations:     rf.Spec.Redis.Tolerations,
 					SecurityContext: getSecurityContext(rf.Spec.Redis.SecurityContext),
+					ImagePullSecrets: rf.Spec.Redis.ImagePullSecrets,
 					Containers: []corev1.Container{
 						{
 							Name:            "redis",
@@ -292,6 +293,7 @@ func generateSentinelDeployment(rf *redisfailoverv1.RedisFailover, labels map[st
 					Affinity:        getAffinity(rf.Spec.Sentinel.Affinity, labels),
 					Tolerations:     rf.Spec.Sentinel.Tolerations,
 					SecurityContext: getSecurityContext(rf.Spec.Sentinel.SecurityContext),
+					ImagePullSecrets: rf.Spec.Sentinel.ImagePullSecrets,
 					InitContainers: []corev1.Container{
 						{
 							Name:            "sentinel-config-copy",


### PR DESCRIPTION
Issue:
redisfailover pods not able to start if you are using secrets in your k8s cluster to access private image repository. (Error: ImagePullBackOff)

Changes proposed on the PR:
- imagePullSecrets configuration added into redisfailovers generate deployment