### PR TITLE
Fix helm chart service labels

### DIFF
--- a/charts/redisoperator/templates/service.yaml
+++ b/charts/redisoperator/templates/service.yaml
@@ -3,11 +3,11 @@ kind: Service
 metadata:
   name: {{ include "name" . | quote }}
   labels:
-    component: app
+    app.kubernetes.io/component: app
 {{ include "common-labels" . | indent 4 }}
 spec:
   selector:
-    component: app
+    app.kubernetes.io/component: app
 {{ include "common-labels" . | indent 4 }}
   ports:
   - name: metrics


### PR DESCRIPTION
Changes proposed on the PR:
- Update the labels for the service template to match other updates.  Service fails to find pods as is.