### PR TITLE
Increase the memory resource for sentinel to avoid its bootstrap fail.

### DIFF
--- a/operator/redisfailover/service/generator.go
+++ b/operator/redisfailover/service/generator.go
@@ -315,11 +315,11 @@ func generateSentinelDeployment(rf *redisfailoverv1.RedisFailover, labels map[st
 							Resources: corev1.ResourceRequirements{
 								Limits: corev1.ResourceList{
 									corev1.ResourceCPU:    resource.MustParse("10m"),
-									corev1.ResourceMemory: resource.MustParse("16Mi"),
+									corev1.ResourceMemory: resource.MustParse("32Mi"),
 								},
 								Requests: corev1.ResourceList{
 									corev1.ResourceCPU:    resource.MustParse("10m"),
-									corev1.ResourceMemory: resource.MustParse("16Mi"),
+									corev1.ResourceMemory: resource.MustParse("32Mi"),
 								},
 							},
 						},


### PR DESCRIPTION
Fixes #176, #164  .

Changes proposed on the PR:
- Increase the memory resource for sentinel deployment.