### PR TITLE
add pod annotations for redis and sentinel pods

### DIFF
--- a/api/redisfailover/v1/types.go
+++ b/api/redisfailover/v1/types.go
@@ -34,6 +34,7 @@ type RedisSettings struct {
 	Affinity          *corev1.Affinity            `json:"affinity,omitempty"`
 	SecurityContext   *corev1.PodSecurityContext  `json:"securityContext,omitempty"`
 	Tolerations       []corev1.Toleration         `json:"tolerations,omitempty"`
+	PodAnnotations    map[string]string           `json:"podAnnotations,omitempty"`
 }
 
 // SentinelSettings defines the specification of the sentinel cluster
@@ -46,6 +47,7 @@ type SentinelSettings struct {
 	Affinity        *corev1.Affinity            `json:"affinity,omitempty"`
 	SecurityContext *corev1.PodSecurityContext  `json:"securityContext,omitempty"`
 	Tolerations     []corev1.Toleration         `json:"tolerations,omitempty"`
+	PodAnnotations  map[string]string           `json:"podAnnotations,omitempty"`
 }
 
 // RedisExporter defines the specification for the redis exporter

--- a/operator/redisfailover/service/generator.go
+++ b/operator/redisfailover/service/generator.go
@@ -183,7 +183,8 @@ func generateRedisStatefulSet(rf *redisfailoverv1.RedisFailover, labels map[stri
 			},
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
-					Labels: labels,
+					Labels:      labels,
+					Annotations: rf.Spec.Redis.PodAnnotations,
 				},
 				Spec: corev1.PodSpec{
 					Affinity:        getAffinity(rf.Spec.Redis.Affinity, labels),
@@ -286,7 +287,8 @@ func generateSentinelDeployment(rf *redisfailoverv1.RedisFailover, labels map[st
 			},
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
-					Labels: labels,
+					Labels:      labels,
+					Annotations: rf.Spec.Sentinel.PodAnnotations,
 				},
 				Spec: corev1.PodSpec{
 					Affinity:        getAffinity(rf.Spec.Sentinel.Affinity, labels),


### PR DESCRIPTION
This PR adds podAnnotations to the redis and sentinel specs. This is very useful when you are required to annotate pods for other external tools or crds. 

Changes proposed on the PR:
- add a podAnnotations map in Redis and Sentinel settings
- copy this map into redis and sentinel generators