### PR TITLE
Fix Permissions Denied on calling shutdown script

### DIFF
--- a/operator/redisfailover/service/generator.go
+++ b/operator/redisfailover/service/generator.go
@@ -233,7 +233,7 @@ func generateRedisStatefulSet(rf *redisfailoverv1.RedisFailover, labels map[stri
 							Lifecycle: &corev1.Lifecycle{
 								PreStop: &corev1.Handler{
 									Exec: &corev1.ExecAction{
-										Command: []string{"/bin/sh", "-c", "/redis-shutdown/shutdown.sh"},
+										Command: []string{"/bin/sh", "/redis-shutdown/shutdown.sh"},
 									},
 								},
 							},


### PR DESCRIPTION
Fixes #162

Changes proposed on the PR:
- `/bin/sh` now executes the shutdown script, passed by path. This doesn't require the executable bit to be set.  
