### PR TITLE
Add Label Whitelisting functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,22 @@ By default, no pod annotations will be applied to Redis nor Sentinel pods.
 
 In order to apply custom pod Annotations, you can provide the `podAnnotations` option inside redis/sentinel spec. An example can be found in the [custom annotations example file](example/redisfailover/custom-annotations.yaml).
 
+### Control of label propagation.
+By default the operator will propagate all labels on the CRD down to the resources that it creates.  This can be problematic if the
+labels on the CRD are not fully under your own control (for example: being deployed by a gitops operator)
+as a change to a labels value can fail on immutable resources such as PodDisruptionBudgets.  To control what labels the operator propagates
+to resource is creates you can modify the labelWhitelist option in the spec.
+
+By default specifying no whitelist or an empty whitelist will cause all labels to still be copied as not to break backwards compatibility.
+
+Items in the array should be regular expressions, see [here](example/redisfailover/control-label-propagation.yaml) as an example of how they can be used and
+[here](https://github.com/google/re2/wiki/Syntax) for a syntax reference.
+
+The whitelist can also be used as a form of blacklist by specifying a regular expression that will not match any label.
+
+
+
+
 ## Connection to the created Redis Failovers
 
 In order to connect to the redis-failover and use it, a [Sentinel-ready](https://redis.io/topics/sentinel-clients) library has to be used. This will connect through the Sentinel service to the Redis node working as a master.

--- a/README.md
+++ b/README.md
@@ -139,8 +139,6 @@ app.kubernetes.io/part-of
 redisfailovers.databases.spotahome.com/name
 ```
 
-
-
 ## Connection to the created Redis Failovers
 
 In order to connect to the redis-failover and use it, a [Sentinel-ready](https://redis.io/topics/sentinel-clients) library has to be used. This will connect through the Sentinel service to the Redis node working as a master.

--- a/README.md
+++ b/README.md
@@ -130,6 +130,14 @@ Items in the array should be regular expressions, see [here](example/redisfailov
 
 The whitelist can also be used as a form of blacklist by specifying a regular expression that will not match any label.
 
+NOTE: The operator will always add the labels it requires for operation to resources.  These are the following:
+```
+app.kubernetes.io/component
+app.kubernetes.io/managed-by
+app.kubernetes.io/name
+app.kubernetes.io/part-of
+redisfailovers.databases.spotahome.com/name
+```
 
 
 

--- a/api/redisfailover/v1/types.go
+++ b/api/redisfailover/v1/types.go
@@ -20,6 +20,7 @@ type RedisFailoverSpec struct {
 	Redis    RedisSettings    `json:"redis,omitempty"`
 	Sentinel SentinelSettings `json:"sentinel,omitempty"`
 	Auth     AuthSettings     `json:"auth,omitempty"`
+	LabelBlacklist []string   `json:"labelBlacklist,omitempty"`
 }
 
 // RedisSettings defines the specification of the redis cluster

--- a/api/redisfailover/v1/types.go
+++ b/api/redisfailover/v1/types.go
@@ -20,7 +20,7 @@ type RedisFailoverSpec struct {
 	Redis    RedisSettings    `json:"redis,omitempty"`
 	Sentinel SentinelSettings `json:"sentinel,omitempty"`
 	Auth     AuthSettings     `json:"auth,omitempty"`
-	LabelBlacklist []string   `json:"labelBlacklist,omitempty"`
+	LabelWhitelist []string   `json:"labelWhitelist,omitempty"`
 }
 
 // RedisSettings defines the specification of the redis cluster

--- a/api/redisfailover/v1/zz_generated.deepcopy.go
+++ b/api/redisfailover/v1/zz_generated.deepcopy.go
@@ -175,11 +175,23 @@ func (in *RedisSettings) DeepCopyInto(out *RedisSettings) {
 			(*in).DeepCopyInto(*out)
 		}
 	}
+	if in.ImagePullSecrets != nil {
+		in, out := &in.ImagePullSecrets, &out.ImagePullSecrets
+		*out = make([]core_v1.LocalObjectReference, len(*in))
+		copy(*out, *in)
+	}
 	if in.Tolerations != nil {
 		in, out := &in.Tolerations, &out.Tolerations
 		*out = make([]core_v1.Toleration, len(*in))
 		for i := range *in {
 			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
+	if in.NodeSelector != nil {
+		in, out := &in.NodeSelector, &out.NodeSelector
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
 		}
 	}
 	if in.PodAnnotations != nil {
@@ -268,11 +280,23 @@ func (in *SentinelSettings) DeepCopyInto(out *SentinelSettings) {
 			(*in).DeepCopyInto(*out)
 		}
 	}
+	if in.ImagePullSecrets != nil {
+		in, out := &in.ImagePullSecrets, &out.ImagePullSecrets
+		*out = make([]core_v1.LocalObjectReference, len(*in))
+		copy(*out, *in)
+	}
 	if in.Tolerations != nil {
 		in, out := &in.Tolerations, &out.Tolerations
 		*out = make([]core_v1.Toleration, len(*in))
 		for i := range *in {
 			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
+	if in.NodeSelector != nil {
+		in, out := &in.NodeSelector, &out.NodeSelector
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
 		}
 	}
 	if in.PodAnnotations != nil {

--- a/api/redisfailover/v1/zz_generated.deepcopy.go
+++ b/api/redisfailover/v1/zz_generated.deepcopy.go
@@ -123,6 +123,11 @@ func (in *RedisFailoverSpec) DeepCopyInto(out *RedisFailoverSpec) {
 	in.Redis.DeepCopyInto(&out.Redis)
 	in.Sentinel.DeepCopyInto(&out.Sentinel)
 	out.Auth = in.Auth
+	if in.LabelBlacklist != nil {
+		in, out := &in.LabelBlacklist, &out.LabelBlacklist
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 
@@ -175,6 +180,13 @@ func (in *RedisSettings) DeepCopyInto(out *RedisSettings) {
 		*out = make([]core_v1.Toleration, len(*in))
 		for i := range *in {
 			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
+	if in.PodAnnotations != nil {
+		in, out := &in.PodAnnotations, &out.PodAnnotations
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
 		}
 	}
 	return
@@ -261,6 +273,13 @@ func (in *SentinelSettings) DeepCopyInto(out *SentinelSettings) {
 		*out = make([]core_v1.Toleration, len(*in))
 		for i := range *in {
 			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
+	if in.PodAnnotations != nil {
+		in, out := &in.PodAnnotations, &out.PodAnnotations
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
 		}
 	}
 	return

--- a/api/redisfailover/v1/zz_generated.deepcopy.go
+++ b/api/redisfailover/v1/zz_generated.deepcopy.go
@@ -123,8 +123,8 @@ func (in *RedisFailoverSpec) DeepCopyInto(out *RedisFailoverSpec) {
 	in.Redis.DeepCopyInto(&out.Redis)
 	in.Sentinel.DeepCopyInto(&out.Sentinel)
 	out.Auth = in.Auth
-	if in.LabelBlacklist != nil {
-		in, out := &in.LabelBlacklist, &out.LabelBlacklist
+	if in.LabelWhitelist != nil {
+		in, out := &in.LabelWhitelist, &out.LabelWhitelist
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}

--- a/example/redisfailover/control-label-propagation.yaml
+++ b/example/redisfailover/control-label-propagation.yaml
@@ -1,0 +1,29 @@
+apiVersion: databases.spotahome.com/v1
+kind: RedisFailover
+metadata:
+  name: redisfailover2
+  labels:
+    # These two labels will be propagated.
+    app.example.com/label1: value
+    app.example.com/label2: value
+    # This one wont be, as there is a non-empty whitelist and the regexp doesnt match it.
+    anotherlabel: value
+spec:
+  sentinel:
+    replicas: 3
+    resources:
+      requests:
+        cpu: 100m
+      limits:
+        memory: 100Mi
+  redis:
+    replicas: 3
+    resources:
+      requests:
+        cpu: 100m
+        memory: 100Mi
+      limits:
+        cpu: 400m
+        memory: 500Mi
+  labelWhitelist:
+  - ^app.example.com.*

--- a/mocks/service/redis/Client.go
+++ b/mocks/service/redis/Client.go
@@ -114,27 +114,6 @@ func (_m *Client) IsMaster(ip string, password string) (bool, error) {
 	return r0, r1
 }
 
-// SlaveIsReady provides a mock function with given fields: ip, password
-func (_m *Client) SlaveIsReady(ip string, password string) (bool, error) {
-	ret := _m.Called(ip, password)
-
-	var r0 bool
-	if rf, ok := ret.Get(0).(func(string, string) bool); ok {
-		r0 = rf(ip, password)
-	} else {
-		r0 = ret.Get(0).(bool)
-	}
-
-	var r1 error
-	if rf, ok := ret.Get(1).(func(string, string) error); ok {
-		r1 = rf(ip, password)
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
-}
-
 // MakeMaster provides a mock function with given fields: ip, password
 func (_m *Client) MakeMaster(ip string, password string) error {
 	ret := _m.Called(ip, password)
@@ -217,4 +196,25 @@ func (_m *Client) SetCustomSentinelConfig(ip string, configs []string) error {
 	}
 
 	return r0
+}
+
+// SlaveIsReady provides a mock function with given fields: ip, password
+func (_m *Client) SlaveIsReady(ip string, password string) (bool, error) {
+	ret := _m.Called(ip, password)
+
+	var r0 bool
+	if rf, ok := ret.Get(0).(func(string, string) bool); ok {
+		r0 = rf(ip, password)
+	} else {
+		r0 = ret.Get(0).(bool)
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(string, string) error); ok {
+		r1 = rf(ip, password)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
 }

--- a/operator/redisfailover/handler.go
+++ b/operator/redisfailover/handler.go
@@ -102,7 +102,16 @@ func (r *RedisFailoverHandler) getLabels(rf *redisfailoverv1.RedisFailover) map[
 	dynLabels := map[string]string{
 		rfLabelNameKey: rf.Name,
 	}
-	return util.MergeLabels(defaultLabels, dynLabels, rf.Labels)
+
+	filteredCustomLabels := rf.Labels
+	for _, label := range rf.Spec.LabelBlacklist {
+		if _, ok := filteredCustomLabels[label]; ok {
+			delete(filteredCustomLabels, label);
+			r.logger.Debugf("Removing %s from labels as it is blacklisted", label)
+		}
+	}
+
+	return util.MergeLabels(defaultLabels, dynLabels, filteredCustomLabels)
 }
 
 func (w *RedisFailoverHandler) createOwnerReferences(rf *redisfailoverv1.RedisFailover) []metav1.OwnerReference {

--- a/operator/redisfailover/handler.go
+++ b/operator/redisfailover/handler.go
@@ -109,10 +109,7 @@ func (r *RedisFailoverHandler) getLabels(rf *redisfailoverv1.RedisFailover) map[
 	if len(rf.Spec.LabelWhitelist) != 0 {
 		for labelKey, labelValue := range rf.Labels {
 			for _, regex := range rf.Spec.LabelWhitelist {
-				compiledRegexp, err := regexp.Compile(regex)
-				if err != nil {
-					r.logger.Fatalf("Unable to compile regex: %s", regex)
-				}
+				compiledRegexp := regexp.MustCompile(regex)
 				match := compiledRegexp.MatchString(labelKey)
 				if match {
 					filteredCustomLabels[labelKey]=labelValue

--- a/operator/redisfailover/handler.go
+++ b/operator/redisfailover/handler.go
@@ -110,8 +110,7 @@ func (r *RedisFailoverHandler) getLabels(rf *redisfailoverv1.RedisFailover) map[
 		for labelKey, labelValue := range rf.Labels {
 			for _, regex := range rf.Spec.LabelWhitelist {
 				compiledRegexp := regexp.MustCompile(regex)
-				match := compiledRegexp.MatchString(labelKey)
-				if match {
+				if match := compiledRegexp.MatchString(labelKey); match {
 					filteredCustomLabels[labelKey]=labelValue
 				}
 			}

--- a/operator/redisfailover/handler.go
+++ b/operator/redisfailover/handler.go
@@ -121,7 +121,6 @@ func (r *RedisFailoverHandler) getLabels(rf *redisfailoverv1.RedisFailover) map[
 		filteredCustomLabels = rf.Labels
 	}
 
-	r.logger.Infof("%#v", filteredCustomLabels)
 	return util.MergeLabels(defaultLabels, dynLabels, filteredCustomLabels)
 }
 

--- a/operator/redisfailover/handler.go
+++ b/operator/redisfailover/handler.go
@@ -120,7 +120,7 @@ func (r *RedisFailoverHandler) getLabels(rf *redisfailoverv1.RedisFailover) map[
 			}
 		}
 	} else {
-		// If no whitelist is specified then dont filter label.
+		// If no whitelist is specified then don't filter the labels.
 		filteredCustomLabels = rf.Labels
 	}
 	return util.MergeLabels(defaultLabels, dynLabels, filteredCustomLabels)


### PR DESCRIPTION
Fixes #179 

Changes proposed in the PR:
The PR adds the ability to filter which labels on the CRD/Spec should be propagated to Kubernetes resources created by the operator via a label whitelist that specifies regexs.

By default (with no whitelist) specified the existing functionality is maintained and all labels are copied, however, once a whitelist regex is specified only labels matching it will be propagated.

This can be used to explicitly whitelist all labels via the pattern .* blacklist all labels by specifying an unmatchable pattern, or somewhere in between if you only want some propagated.

This solves our issue of our gitops operator (Flux) modifying labels on the Spec and the operator attempting to update the PDB, which are immutable in k8's < 1.15 and failing as a result.