### PR TITLE
Fix uid capatalization in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ default: build
 .PHONY: docker-build
 docker-build: deps-development
 	docker build \
-		--build-arg UID=$(UID) \
+		--build-arg uid=$(UID) \
 		-t $(REPOSITORY)-dev:latest \
 		-t $(REPOSITORY)-dev:$(COMMIT) \
 		-f $(DEV_DIR)/Dockerfile \


### PR DESCRIPTION
Changes proposed in the PR:
-  There is currently a bug with the makefile with the UID parameter that is passed to docker as a build arg.  Docker expects it as a lowercase string and the makefile is providing it as an uppercase one.  This likely wasn't noticed until now it defaults to UID 1000 which will usually exist on a Linux install but won't on macOS (I'm id 501).