### PR TITLE
Fix174

### DIFF
--- a/api/redisfailover/v1/types.go
+++ b/api/redisfailover/v1/types.go
@@ -1,6 +1,7 @@
 package v1
 
 import (
+	"encoding/json"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -25,6 +26,7 @@ type RedisFailoverSpec struct {
 // RedisSettings defines the specification of the redis cluster
 type RedisSettings struct {
 	Image             string                      `json:"image,omitempty"`
+	ImagePullPolicy   ImagePullPolicy             `json:"imagePullPolicy,omitempty"`
 	Replicas          int32                       `json:"replicas,omitempty"`
 	Resources         corev1.ResourceRequirements `json:"resources,omitempty"`
 	CustomConfig      []string                    `json:"customConfig,omitempty"`
@@ -43,6 +45,7 @@ type RedisSettings struct {
 // SentinelSettings defines the specification of the sentinel cluster
 type SentinelSettings struct {
 	Image           string                      `json:"image,omitempty"`
+	ImagePullPolicy ImagePullPolicy             `json:"imagePullPolicy,omitempty"`
 	Replicas        int32                       `json:"replicas,omitempty"`
 	Resources       corev1.ResourceRequirements `json:"resources,omitempty"`
 	CustomConfig    []string                    `json:"customConfig,omitempty"`
@@ -62,8 +65,9 @@ type AuthSettings struct {
 
 // RedisExporter defines the specification for the redis exporter
 type RedisExporter struct {
-	Enabled bool   `json:"enabled,omitempty"`
-	Image   string `json:"image,omitempty"`
+	Enabled         bool            `json:"enabled,omitempty"`
+	Image           string          `json:"image,omitempty"`
+	ImagePullPolicy ImagePullPolicy `json:"imagePullPolicy,omitempty"`
 }
 
 // RedisStorage defines the structure used to store the Redis Data
@@ -81,4 +85,21 @@ type RedisFailoverList struct {
 	metav1.ListMeta `json:"metadata"`
 
 	Items []RedisFailover `json:"items"`
+}
+
+// ImagePullPolicy defines the pull policy with a default of Always
+type ImagePullPolicy corev1.PullPolicy
+
+// UnmarshalJSON sets the default value to Always on JSON decode
+func (i *ImagePullPolicy) UnmarshalJSON(b []byte) error {
+	var s string
+	if err := json.Unmarshal(b, &s); err != nil {
+		return err
+	}
+	if s == "" {
+		*i = ImagePullPolicy("Always")
+		return nil
+	}
+	*i = ImagePullPolicy(s)
+	return nil
 }

--- a/api/redisfailover/v1/types.go
+++ b/api/redisfailover/v1/types.go
@@ -1,7 +1,6 @@
 package v1
 
 import (
-	"encoding/json"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -26,7 +25,7 @@ type RedisFailoverSpec struct {
 // RedisSettings defines the specification of the redis cluster
 type RedisSettings struct {
 	Image             string                      `json:"image,omitempty"`
-	ImagePullPolicy   ImagePullPolicy             `json:"imagePullPolicy,omitempty"`
+	ImagePullPolicy   corev1.PullPolicy           `json:"imagePullPolicy,omitempty"`
 	Replicas          int32                       `json:"replicas,omitempty"`
 	Resources         corev1.ResourceRequirements `json:"resources,omitempty"`
 	CustomConfig      []string                    `json:"customConfig,omitempty"`
@@ -45,7 +44,7 @@ type RedisSettings struct {
 // SentinelSettings defines the specification of the sentinel cluster
 type SentinelSettings struct {
 	Image           string                      `json:"image,omitempty"`
-	ImagePullPolicy ImagePullPolicy             `json:"imagePullPolicy,omitempty"`
+	ImagePullPolicy corev1.PullPolicy           `json:"imagePullPolicy,omitempty"`
 	Replicas        int32                       `json:"replicas,omitempty"`
 	Resources       corev1.ResourceRequirements `json:"resources,omitempty"`
 	CustomConfig    []string                    `json:"customConfig,omitempty"`
@@ -65,9 +64,9 @@ type AuthSettings struct {
 
 // RedisExporter defines the specification for the redis exporter
 type RedisExporter struct {
-	Enabled         bool            `json:"enabled,omitempty"`
-	Image           string          `json:"image,omitempty"`
-	ImagePullPolicy ImagePullPolicy `json:"imagePullPolicy,omitempty"`
+	Enabled         bool              `json:"enabled,omitempty"`
+	Image           string            `json:"image,omitempty"`
+	ImagePullPolicy corev1.PullPolicy `json:"imagePullPolicy,omitempty"`
 }
 
 // RedisStorage defines the structure used to store the Redis Data
@@ -85,21 +84,4 @@ type RedisFailoverList struct {
 	metav1.ListMeta `json:"metadata"`
 
 	Items []RedisFailover `json:"items"`
-}
-
-// ImagePullPolicy defines the pull policy with a default of Always
-type ImagePullPolicy corev1.PullPolicy
-
-// UnmarshalJSON sets the default value to Always on JSON decode
-func (i *ImagePullPolicy) UnmarshalJSON(b []byte) error {
-	var s string
-	if err := json.Unmarshal(b, &s); err != nil {
-		return err
-	}
-	if s == "" {
-		*i = ImagePullPolicy("Always")
-		return nil
-	}
-	*i = ImagePullPolicy(s)
-	return nil
 }

--- a/example/redisfailover/custom-image.yaml
+++ b/example/redisfailover/custom-image.yaml
@@ -6,6 +6,8 @@ spec:
   sentinel:
     replicas: 3
     image: redis:4.0-alpine
+    imagePullPolicy: IfNotPresent
   redis:
     replicas: 3
     image: redis:4.0-alpine
+    imagePullPolicy: IfNotPresent

--- a/operator/redisfailover/service/generator.go
+++ b/operator/redisfailover/service/generator.go
@@ -200,7 +200,7 @@ func generateRedisStatefulSet(rf *redisfailoverv1.RedisFailover, labels map[stri
 						{
 							Name:            "redis",
 							Image:           rf.Spec.Redis.Image,
-							ImagePullPolicy: "Always",
+							ImagePullPolicy: corev1.PullPolicy(rf.Spec.Redis.ImagePullPolicy),
 							Ports: []corev1.ContainerPort{
 								{
 									Name:          "redis",
@@ -306,7 +306,7 @@ func generateSentinelDeployment(rf *redisfailoverv1.RedisFailover, labels map[st
 						{
 							Name:            "sentinel-config-copy",
 							Image:           rf.Spec.Sentinel.Image,
-							ImagePullPolicy: "IfNotPresent",
+							ImagePullPolicy: corev1.PullPolicy(rf.Spec.Sentinel.ImagePullPolicy),
 							VolumeMounts: []corev1.VolumeMount{
 								{
 									Name:      "sentinel-config",
@@ -338,7 +338,7 @@ func generateSentinelDeployment(rf *redisfailoverv1.RedisFailover, labels map[st
 						{
 							Name:            "sentinel",
 							Image:           rf.Spec.Sentinel.Image,
-							ImagePullPolicy: "Always",
+							ImagePullPolicy: corev1.PullPolicy(rf.Spec.Sentinel.ImagePullPolicy),
 							Ports: []corev1.ContainerPort{
 								{
 									Name:          "sentinel",
@@ -438,7 +438,7 @@ func createRedisExporterContainer(rf *redisfailoverv1.RedisFailover) corev1.Cont
 	container := corev1.Container{
 		Name:            exporterContainerName,
 		Image:           rf.Spec.Redis.Exporter.Image,
-		ImagePullPolicy: "Always",
+		ImagePullPolicy: corev1.PullPolicy(rf.Spec.Redis.Exporter.ImagePullPolicy),
 		Env: []corev1.EnvVar{
 			{
 				Name: "REDIS_ALIAS",

--- a/operator/redisfailover/service/generator.go
+++ b/operator/redisfailover/service/generator.go
@@ -641,7 +641,7 @@ func getSentinelCommand(rf *redisfailoverv1.RedisFailover) []string {
 
 func pullPolicy(specPolicy corev1.PullPolicy) corev1.PullPolicy {
 	if specPolicy == "" {
-		return "Always"
+		return corev1.PullAlways
 	}
 	return specPolicy
 }

--- a/operator/redisfailover/service/generator.go
+++ b/operator/redisfailover/service/generator.go
@@ -200,7 +200,7 @@ func generateRedisStatefulSet(rf *redisfailoverv1.RedisFailover, labels map[stri
 						{
 							Name:            "redis",
 							Image:           rf.Spec.Redis.Image,
-							ImagePullPolicy: corev1.PullPolicy(rf.Spec.Redis.ImagePullPolicy),
+							ImagePullPolicy: pullPolicy(rf.Spec.Redis.ImagePullPolicy),
 							Ports: []corev1.ContainerPort{
 								{
 									Name:          "redis",
@@ -306,7 +306,7 @@ func generateSentinelDeployment(rf *redisfailoverv1.RedisFailover, labels map[st
 						{
 							Name:            "sentinel-config-copy",
 							Image:           rf.Spec.Sentinel.Image,
-							ImagePullPolicy: corev1.PullPolicy(rf.Spec.Sentinel.ImagePullPolicy),
+							ImagePullPolicy: pullPolicy(rf.Spec.Sentinel.ImagePullPolicy),
 							VolumeMounts: []corev1.VolumeMount{
 								{
 									Name:      "sentinel-config",
@@ -338,7 +338,7 @@ func generateSentinelDeployment(rf *redisfailoverv1.RedisFailover, labels map[st
 						{
 							Name:            "sentinel",
 							Image:           rf.Spec.Sentinel.Image,
-							ImagePullPolicy: corev1.PullPolicy(rf.Spec.Sentinel.ImagePullPolicy),
+							ImagePullPolicy: pullPolicy(rf.Spec.Sentinel.ImagePullPolicy),
 							Ports: []corev1.ContainerPort{
 								{
 									Name:          "sentinel",
@@ -438,7 +438,7 @@ func createRedisExporterContainer(rf *redisfailoverv1.RedisFailover) corev1.Cont
 	container := corev1.Container{
 		Name:            exporterContainerName,
 		Image:           rf.Spec.Redis.Exporter.Image,
-		ImagePullPolicy: corev1.PullPolicy(rf.Spec.Redis.Exporter.ImagePullPolicy),
+		ImagePullPolicy: pullPolicy(rf.Spec.Redis.Exporter.ImagePullPolicy),
 		Env: []corev1.EnvVar{
 			{
 				Name: "REDIS_ALIAS",
@@ -637,4 +637,11 @@ func getSentinelCommand(rf *redisfailoverv1.RedisFailover) []string {
 		fmt.Sprintf("/redis/%s", sentinelConfigFileName),
 		"--sentinel",
 	}
+}
+
+func pullPolicy(specPolicy corev1.PullPolicy) corev1.PullPolicy {
+	if specPolicy == "" {
+		return "Always"
+	}
+	return specPolicy
 }


### PR DESCRIPTION
Fixes #174 

Changes proposed on the PR:
- Expose imagePullPolicy for Redis, Sentinel and Exporter images
- Updates custom-image.yaml example spec

Changes from previous commit:
- Changed where the pull policy is defaulted to `Always` because doing it on spec decode did not set the default in the absence of the property in the source YAML
- Added unit tests

_Improved version of https://github.com/spotahome/redis-operator/pull/192_