### PR TITLE
change update strategy

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -668,7 +668,7 @@
     "github.com/stretchr/testify/assert",
     "github.com/stretchr/testify/mock",
     "github.com/stretchr/testify/require",
-    "k8s.io/api/apps/v1beta2",
+    "k8s.io/api/apps/v1",
     "k8s.io/api/core/v1",
     "k8s.io/api/policy/v1beta1",
     "k8s.io/api/rbac/v1",

--- a/charts/redisoperator/Chart.yaml
+++ b/charts/redisoperator/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for the Spotahome Redis Operator
 name: redisoperator
-version: 3.0.0
+version: 3.1.0

--- a/charts/redisoperator/Chart.yaml
+++ b/charts/redisoperator/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for the Spotahome Redis Operator
 name: redisoperator
-version: 3.1.0
+version: 3.0.0

--- a/mocks/operator/redisfailover/service/RedisFailoverCheck.go
+++ b/mocks/operator/redisfailover/service/RedisFailoverCheck.go
@@ -43,6 +43,27 @@ func (_m *RedisFailoverCheck) CheckRedisNumber(rFailover *v1.RedisFailover) erro
 	return r0
 }
 
+// CheckRedisSyncing provides a mock function with given fields: slaveIP, rFailover
+func (_m *RedisFailoverCheck) CheckRedisSyncing(slaveIP string, rFailover *v1.RedisFailover) (bool, error) {
+	ret := _m.Called(slaveIP, rFailover)
+
+	var r0 bool
+	if rf, ok := ret.Get(0).(func(string, *v1.RedisFailover) bool); ok {
+		r0 = rf(slaveIP, rFailover)
+	} else {
+		r0 = ret.Get(0).(bool)
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(string, *v1.RedisFailover) error); ok {
+		r1 = rf(slaveIP, rFailover)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // CheckSentinelMonitor provides a mock function with given fields: sentinel, monitor
 func (_m *RedisFailoverCheck) CheckSentinelMonitor(sentinel string, monitor string) error {
 	ret := _m.Called(sentinel, monitor)
@@ -162,8 +183,73 @@ func (_m *RedisFailoverCheck) GetNumberMasters(rFailover *v1.RedisFailover) (int
 	return r0, r1
 }
 
+// GetRedisRevisionHash provides a mock function with given fields: podName, rFailover
+func (_m *RedisFailoverCheck) GetRedisRevisionHash(podName string, rFailover *v1.RedisFailover) (string, error) {
+	ret := _m.Called(podName, rFailover)
+
+	var r0 string
+	if rf, ok := ret.Get(0).(func(string, *v1.RedisFailover) string); ok {
+		r0 = rf(podName, rFailover)
+	} else {
+		r0 = ret.Get(0).(string)
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(string, *v1.RedisFailover) error); ok {
+		r1 = rf(podName, rFailover)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // GetRedisesIPs provides a mock function with given fields: rFailover
 func (_m *RedisFailoverCheck) GetRedisesIPs(rFailover *v1.RedisFailover) ([]string, error) {
+	ret := _m.Called(rFailover)
+
+	var r0 []string
+	if rf, ok := ret.Get(0).(func(*v1.RedisFailover) []string); ok {
+		r0 = rf(rFailover)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]string)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(*v1.RedisFailover) error); ok {
+		r1 = rf(rFailover)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// GetRedisesMasterPod provides a mock function with given fields: rFailover
+func (_m *RedisFailoverCheck) GetRedisesMasterPod(rFailover *v1.RedisFailover) (string, error) {
+	ret := _m.Called(rFailover)
+
+	var r0 string
+	if rf, ok := ret.Get(0).(func(*v1.RedisFailover) string); ok {
+		r0 = rf(rFailover)
+	} else {
+		r0 = ret.Get(0).(string)
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(*v1.RedisFailover) error); ok {
+		r1 = rf(rFailover)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// GetRedisesSlavesPods provides a mock function with given fields: rFailover
+func (_m *RedisFailoverCheck) GetRedisesSlavesPods(rFailover *v1.RedisFailover) ([]string, error) {
 	ret := _m.Called(rFailover)
 
 	var r0 []string
@@ -196,6 +282,27 @@ func (_m *RedisFailoverCheck) GetSentinelsIPs(rFailover *v1.RedisFailover) ([]st
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]string)
 		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(*v1.RedisFailover) error); ok {
+		r1 = rf(rFailover)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// GetStatefulSetUpdateRevision provides a mock function with given fields: rFailover
+func (_m *RedisFailoverCheck) GetStatefulSetUpdateRevision(rFailover *v1.RedisFailover) (string, error) {
+	ret := _m.Called(rFailover)
+
+	var r0 string
+	if rf, ok := ret.Get(0).(func(*v1.RedisFailover) string); ok {
+		r0 = rf(rFailover)
+	} else {
+		r0 = ret.Get(0).(string)
 	}
 
 	var r1 error

--- a/mocks/operator/redisfailover/service/RedisFailoverCheck.go
+++ b/mocks/operator/redisfailover/service/RedisFailoverCheck.go
@@ -43,8 +43,8 @@ func (_m *RedisFailoverCheck) CheckRedisNumber(rFailover *v1.RedisFailover) erro
 	return r0
 }
 
-// CheckRedisSyncing provides a mock function with given fields: slaveIP, rFailover
-func (_m *RedisFailoverCheck) CheckRedisSyncing(slaveIP string, rFailover *v1.RedisFailover) (bool, error) {
+// CheckRedisSlavesReady provides a mock function with given fields: slaveIP, rFailover
+func (_m *RedisFailoverCheck) CheckRedisSlavesReady(slaveIP string, rFailover *v1.RedisFailover) (bool, error) {
 	ret := _m.Called(slaveIP, rFailover)
 
 	var r0 bool

--- a/mocks/operator/redisfailover/service/RedisFailoverHeal.go
+++ b/mocks/operator/redisfailover/service/RedisFailoverHeal.go
@@ -13,6 +13,20 @@ type RedisFailoverHeal struct {
 	mock.Mock
 }
 
+// DeletePod provides a mock function with given fields: podName, rFailover
+func (_m *RedisFailoverHeal) DeletePod(podName string, rFailover *v1.RedisFailover) error {
+	ret := _m.Called(podName, rFailover)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(string, *v1.RedisFailover) error); ok {
+		r0 = rf(podName, rFailover)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 // MakeMaster provides a mock function with given fields: ip, rFailover
 func (_m *RedisFailoverHeal) MakeMaster(ip string, rFailover *v1.RedisFailover) error {
 	ret := _m.Called(ip, rFailover)

--- a/mocks/service/redis/Client.go
+++ b/mocks/service/redis/Client.go
@@ -114,6 +114,27 @@ func (_m *Client) IsMaster(ip string, password string) (bool, error) {
 	return r0, r1
 }
 
+// IsSyncing provides a mock function with given fields: ip, password
+func (_m *Client) IsSyncing(ip string, password string) (bool, error) {
+	ret := _m.Called(ip, password)
+
+	var r0 bool
+	if rf, ok := ret.Get(0).(func(string, string) bool); ok {
+		r0 = rf(ip, password)
+	} else {
+		r0 = ret.Get(0).(bool)
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(string, string) error); ok {
+		r1 = rf(ip, password)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // MakeMaster provides a mock function with given fields: ip, password
 func (_m *Client) MakeMaster(ip string, password string) error {
 	ret := _m.Called(ip, password)

--- a/mocks/service/redis/Client.go
+++ b/mocks/service/redis/Client.go
@@ -114,8 +114,8 @@ func (_m *Client) IsMaster(ip string, password string) (bool, error) {
 	return r0, r1
 }
 
-// IsSyncing provides a mock function with given fields: ip, password
-func (_m *Client) IsSyncing(ip string, password string) (bool, error) {
+// SlaveIsReady provides a mock function with given fields: ip, password
+func (_m *Client) SlaveIsReady(ip string, password string) (bool, error) {
 	ret := _m.Called(ip, password)
 
 	var r0 bool

--- a/operator/redisfailover/checker.go
+++ b/operator/redisfailover/checker.go
@@ -57,7 +57,6 @@ func (r *RedisFailoverHandler) UpdateRedisesPods(rf *redisfailoverv1.RedisFailov
 
 	masterRevision, err := r.rfChecker.GetRedisRevisionHash(master, rf)
 	if masterRevision != ssUR {
-		//Delete pod and wait next round to check if the new one is synced
 		r.rfHealer.DeletePod(master, rf)
 		return nil
 	}

--- a/operator/redisfailover/checker.go
+++ b/operator/redisfailover/checker.go
@@ -39,7 +39,7 @@ func (r *RedisFailoverHandler) UpdateRedisesPods(rf *redisfailoverv1.RedisFailov
 		return err
 	}
 
-	//If some slaves are not in the correct version, delete them
+	// Update stale pods with slave role
 	for _, pod := range redisesPods {
 		revision, err := r.rfChecker.GetRedisRevisionHash(pod, rf)
 		if err != nil {

--- a/operator/redisfailover/checker.go
+++ b/operator/redisfailover/checker.go
@@ -18,7 +18,7 @@ func (r *RedisFailoverHandler) UpdateRedisesPods(rf *redisfailoverv1.RedisFailov
 		return err
 	}
 
-	//If we have syincing nodes we finish checks
+	// No perform updates when nodes are syncing.
 	for _, rp := range redises {
 		sync, err := r.rfChecker.CheckRedisSyncing(rp, rf)
 		if err != nil {

--- a/operator/redisfailover/checker.go
+++ b/operator/redisfailover/checker.go
@@ -11,7 +11,7 @@ const (
 	timeToPrepare = 2 * time.Minute
 )
 
-//Checks if the running version of pods are equal to the statefulset one
+//UpdateRedisesPods if the running version of pods are equal to the statefulset one
 func (r *RedisFailoverHandler) UpdateRedisesPods(rf *redisfailoverv1.RedisFailover) error {
 	redises, err := r.rfChecker.GetRedisesIPs(rf)
 	if err != nil {

--- a/operator/redisfailover/checker.go
+++ b/operator/redisfailover/checker.go
@@ -52,7 +52,7 @@ func (r *RedisFailoverHandler) UpdateRedisesPods(rf *redisfailoverv1.RedisFailov
 		}
 	}
 
-	//If all slaves are up and synced, we check master
+	// Update stale pod with role master
 	master, err := r.rfChecker.GetRedisesMasterPod(rf)
 
 	masterRevision, err := r.rfChecker.GetRedisRevisionHash(master, rf)

--- a/operator/redisfailover/checker.go
+++ b/operator/redisfailover/checker.go
@@ -11,6 +11,61 @@ const (
 	timeToPrepare = 2 * time.Minute
 )
 
+//Checks if the running version of pods are equal to the statefulset one
+func (r *RedisFailoverHandler) UpdateRedisesPods(rf *redisfailoverv1.RedisFailover) error {
+	redises, err := r.rfChecker.GetRedisesIPs(rf)
+	if err != nil {
+		return err
+	}
+
+	//If we have syincing nodes we finish checks
+	for _, rp := range redises {
+		sync, err := r.rfChecker.CheckRedisSyncing(rp, rf)
+		if err != nil {
+			return err
+		}
+		if sync {
+			//currently syncing, we wait next round
+			return nil
+		}
+	}
+
+	ssUR, err := r.rfChecker.GetStatefulSetUpdateRevision(rf)
+	if err != nil {
+		return err
+	}
+
+	redisesPods, err := r.rfChecker.GetRedisesSlavesPods(rf)
+	if err != nil {
+		return err
+	}
+
+	//If some slaves are not in the correct version, delete them
+	for _, pod := range redisesPods {
+		revision, err := r.rfChecker.GetRedisRevisionHash(pod, rf)
+		if err != nil {
+			return err
+		}
+		if revision != ssUR {
+			//Delete pod and wait next round to check if the new one is synced
+			r.rfHealer.DeletePod(pod, rf)
+			return nil
+		}
+	}
+
+	//If all slaves are up and synced, we check master
+	master, err := r.rfChecker.GetRedisesMasterPod(rf)
+
+	masterRevision, err := r.rfChecker.GetRedisRevisionHash(master, rf)
+	if masterRevision != ssUR {
+		//Delete pod and wait next round to check if the new one is synced
+		r.rfHealer.DeletePod(master, rf)
+		return nil
+	}
+
+	return nil
+}
+
 func (r *RedisFailoverHandler) CheckAndHeal(rf *redisfailoverv1.RedisFailover) error {
 	// Number of redis is equal as the set on the RF spec
 	// Number of sentinel is equal as the set on the RF spec
@@ -85,6 +140,11 @@ func (r *RedisFailoverHandler) CheckAndHeal(rf *redisfailoverv1.RedisFailover) e
 		if err := r.rfHealer.SetRedisCustomConfig(rip, rf); err != nil {
 			return err
 		}
+	}
+
+	err = r.UpdateRedisesPods(rf)
+	if err != nil {
+		return err
 	}
 
 	sentinels, err := r.rfChecker.GetSentinelsIPs(rf)

--- a/operator/redisfailover/checker.go
+++ b/operator/redisfailover/checker.go
@@ -25,7 +25,6 @@ func (r *RedisFailoverHandler) UpdateRedisesPods(rf *redisfailoverv1.RedisFailov
 			return err
 		}
 		if sync {
-			//currently syncing, we wait next round
 			return nil
 		}
 	}

--- a/operator/redisfailover/checker_test.go
+++ b/operator/redisfailover/checker_test.go
@@ -8,6 +8,10 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"github.com/spotahome/redis-operator/log"
 	"github.com/spotahome/redis-operator/metrics"
 	mRFService "github.com/spotahome/redis-operator/mocks/operator/redisfailover/service"
@@ -165,7 +169,12 @@ func TestCheckAndHeal(t *testing.T) {
 					mrfc.On("CheckAllSlavesFromMaster", master, rf).Once().Return(errors.New(""))
 					mrfh.On("SetMasterOnAll", master, rf).Once().Return(nil)
 				}
-				mrfc.On("GetRedisesIPs", rf).Once().Return([]string{master}, nil)
+				mrfc.On("GetRedisesIPs", rf).Twice().Return([]string{master}, nil)
+				mrfc.On("CheckRedisSyncing", master, rf).Once().Return(false, nil)
+				mrfc.On("GetStatefulSetUpdateRevision", rf).Once().Return("1", nil)
+				mrfc.On("GetRedisesSlavesPods", rf).Once().Return([]string{}, nil)
+				mrfc.On("GetRedisesMasterPod", rf).Once().Return(master, nil)
+				mrfc.On("GetRedisRevisionHash", master, rf).Once().Return("1", nil)
 				mrfh.On("SetRedisCustomConfig", master, rf).Once().Return(nil)
 				mrfc.On("GetSentinelsIPs", rf).Once().Return([]string{sentinel}, nil)
 				if test.sentinelMonitorOK {
@@ -199,6 +208,288 @@ func TestCheckAndHeal(t *testing.T) {
 			}
 			mrfc.AssertExpectations(t)
 			mrfh.AssertExpectations(t)
+		})
+	}
+}
+
+func TestUpdate(t *testing.T) {
+	type podStatus struct {
+		pod     corev1.Pod
+		syncing bool
+		master  bool
+	}
+	tests := []struct {
+		name        string
+		pods        []podStatus
+		ssVersion   string
+		errExpected error
+		syncing     bool
+	}{
+		{
+			name: "all ok, no change needed",
+			pods: []podStatus{
+				{
+					pod: corev1.Pod{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "slave1",
+							Labels: map[string]string{
+								appsv1.ControllerRevisionHashLabelKey: "10",
+							},
+						},
+						Status: corev1.PodStatus{
+							PodIP: "0.0.0.0",
+						},
+					},
+					master:  false,
+					syncing: false,
+				},
+				{
+					pod: corev1.Pod{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "slave2",
+							Labels: map[string]string{
+								appsv1.ControllerRevisionHashLabelKey: "10",
+							},
+						},
+						Status: corev1.PodStatus{
+							PodIP: "0.0.0.1",
+						},
+					},
+					master:  false,
+					syncing: false,
+				},
+				{
+					pod: corev1.Pod{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "master",
+							Labels: map[string]string{
+								appsv1.ControllerRevisionHashLabelKey: "10",
+							},
+						},
+						Status: corev1.PodStatus{
+							PodIP: "1.1.1.1",
+						},
+					},
+					master:  true,
+					syncing: false,
+				},
+			},
+			ssVersion:   "10",
+			errExpected: nil,
+		},
+		{
+			name: "syncing",
+			pods: []podStatus{
+				{
+					pod: corev1.Pod{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "slave1",
+							Labels: map[string]string{
+								appsv1.ControllerRevisionHashLabelKey: "10",
+							},
+						},
+						Status: corev1.PodStatus{
+							PodIP: "0.0.0.0",
+						},
+					},
+					master:  false,
+					syncing: false,
+				},
+				{
+					pod: corev1.Pod{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "slave2",
+							Labels: map[string]string{
+								appsv1.ControllerRevisionHashLabelKey: "10",
+							},
+						},
+						Status: corev1.PodStatus{
+							PodIP: "0.0.0.1",
+						},
+					},
+					master:  false,
+					syncing: true,
+				},
+				{
+					pod: corev1.Pod{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "master",
+							Labels: map[string]string{
+								appsv1.ControllerRevisionHashLabelKey: "10",
+							},
+						},
+						Status: corev1.PodStatus{
+							PodIP: "1.1.1.1",
+						},
+					},
+					master:  true,
+					syncing: false,
+				},
+			},
+			ssVersion:   "10",
+			errExpected: nil,
+		},
+		{
+			name: "pod version incorrect",
+			pods: []podStatus{
+				{
+					pod: corev1.Pod{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "slave1",
+							Labels: map[string]string{
+								appsv1.ControllerRevisionHashLabelKey: "10",
+							},
+						},
+						Status: corev1.PodStatus{
+							PodIP: "0.0.0.0",
+						},
+					},
+					master:  false,
+					syncing: false,
+				},
+				{
+					pod: corev1.Pod{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "slave2",
+							Labels: map[string]string{
+								appsv1.ControllerRevisionHashLabelKey: "10",
+							},
+						},
+						Status: corev1.PodStatus{
+							PodIP: "0.0.0.1",
+						},
+					},
+					master:  false,
+					syncing: true,
+				},
+				{
+					pod: corev1.Pod{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "master",
+							Labels: map[string]string{
+								appsv1.ControllerRevisionHashLabelKey: "10",
+							},
+						},
+						Status: corev1.PodStatus{
+							PodIP: "1.1.1.1",
+						},
+					},
+					master:  true,
+					syncing: false,
+				},
+			},
+			ssVersion:   "1",
+			errExpected: nil,
+		},
+		{
+			name: "master version incorrect",
+			pods: []podStatus{
+				{
+					pod: corev1.Pod{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "slave1",
+							Labels: map[string]string{
+								appsv1.ControllerRevisionHashLabelKey: "10",
+							},
+						},
+						Status: corev1.PodStatus{
+							PodIP: "0.0.0.0",
+						},
+					},
+					master:  false,
+					syncing: false,
+				},
+				{
+					pod: corev1.Pod{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "slave2",
+							Labels: map[string]string{
+								appsv1.ControllerRevisionHashLabelKey: "10",
+							},
+						},
+						Status: corev1.PodStatus{
+							PodIP: "0.0.0.1",
+						},
+					},
+					master:  false,
+					syncing: true,
+				},
+				{
+					pod: corev1.Pod{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "master",
+							Labels: map[string]string{
+								appsv1.ControllerRevisionHashLabelKey: "1",
+							},
+						},
+						Status: corev1.PodStatus{
+							PodIP: "1.1.1.1",
+						},
+					},
+					master:  true,
+					syncing: false,
+				},
+			},
+			ssVersion:   "10",
+			errExpected: nil,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert := assert.New(t)
+
+			rf := generateRF(false)
+
+			config := generateConfig()
+			mrfs := &mRFService.RedisFailoverClient{}
+
+			mrfc := &mRFService.RedisFailoverCheck{}
+			mrfc.On("GetRedisesIPs", rf).Once().Return([]string{"0.0.0.0", "0.0.0.1", "1.1.1.1"}, nil)
+
+			next := true
+
+			for _, pod := range test.pods {
+				mrfc.On("CheckRedisSyncing", pod.pod.Status.PodIP, rf).Once().Return(pod.syncing, nil)
+				if pod.syncing {
+					next = false
+					break
+				}
+			}
+			mrfh := &mRFService.RedisFailoverHeal{}
+
+			if next {
+				mrfc.On("GetStatefulSetUpdateRevision", rf).Once().Return(test.ssVersion, nil)
+				mrfc.On("GetRedisesSlavesPods", rf).Once().Return([]string{"slave1", "slave2"}, nil)
+
+				for _, pod := range test.pods {
+					mrfc.On("GetRedisRevisionHash", pod.pod.ObjectMeta.Name, rf).Once().Return(pod.pod.ObjectMeta.Labels[appsv1.ControllerRevisionHashLabelKey], nil)
+					if pod.pod.ObjectMeta.Labels[appsv1.ControllerRevisionHashLabelKey] != test.ssVersion {
+						mrfh.On("DeletePod", mock.Anything, mock.Anything)
+						if pod.master == false {
+							next = false
+							break
+						}
+					}
+				}
+				if next {
+					mrfc.On("GetRedisesMasterPod", rf).Once().Return("master", nil)
+				}
+			}
+
+			mk := &mK8SService.Services{}
+
+			handler := rfOperator.NewRedisFailoverHandler(config, mrfs, mrfc, mrfh, mk, metrics.Dummy, log.Dummy)
+			err := handler.UpdateRedisesPods(rf)
+
+			if test.errExpected != nil {
+				assert.Error(err)
+			} else {
+				assert.NoError(err)
+			}
+
+			mrfc.AssertExpectations(t)
+			mrfh.AssertExpectations(t)
+
 		})
 	}
 }

--- a/operator/redisfailover/service/check.go
+++ b/operator/redisfailover/service/check.go
@@ -31,7 +31,7 @@ type RedisFailoverCheck interface {
 	GetRedisesMasterPod(rFailover *redisfailoverv1.RedisFailover) (string, error)
 	GetStatefulSetUpdateRevision(rFailover *redisfailoverv1.RedisFailover) (string, error)
 	GetRedisRevisionHash(podName string, rFailover *redisfailoverv1.RedisFailover) (string, error)
-	CheckRedisSyncing(slaveIP string, rFailover *redisfailoverv1.RedisFailover) (bool, error)
+	CheckRedisSlavesReady(slaveIP string, rFailover *redisfailoverv1.RedisFailover) (bool, error)
 }
 
 // RedisFailoverChecker is our implementation of RedisFailoverCheck interface
@@ -325,12 +325,12 @@ func (r *RedisFailoverChecker) GetRedisRevisionHash(podName string, rFailover *r
 	return val, nil
 }
 
-// CheckRedisSyncing returns true if the slave is still syncing
-func (r *RedisFailoverChecker) CheckRedisSyncing(ip string, rFailover *redisfailoverv1.RedisFailover) (bool, error) {
+// CheckRedisSlavesReady returns true if the slave is ready (sync, connected, etc)
+func (r *RedisFailoverChecker) CheckRedisSlavesReady(ip string, rFailover *redisfailoverv1.RedisFailover) (bool, error) {
 	password, err := k8s.GetRedisPassword(r.k8sService, rFailover)
 	if err != nil {
 		return false, err
 	}
 
-	return r.redisClient.IsSyncing(ip, password)
+	return r.redisClient.SlaveIsReady(ip, password)
 }

--- a/operator/redisfailover/service/check.go
+++ b/operator/redisfailover/service/check.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"time"
 
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 
 	redisfailoverv1 "github.com/spotahome/redis-operator/api/redisfailover/v1"
@@ -26,6 +27,11 @@ type RedisFailoverCheck interface {
 	GetRedisesIPs(rFailover *redisfailoverv1.RedisFailover) ([]string, error)
 	GetSentinelsIPs(rFailover *redisfailoverv1.RedisFailover) ([]string, error)
 	GetMinimumRedisPodTime(rFailover *redisfailoverv1.RedisFailover) (time.Duration, error)
+	GetRedisesSlavesPods(rFailover *redisfailoverv1.RedisFailover) ([]string, error)
+	GetRedisesMasterPod(rFailover *redisfailoverv1.RedisFailover) (string, error)
+	GetStatefulSetUpdateRevision(rFailover *redisfailoverv1.RedisFailover) (string, error)
+	GetRedisRevisionHash(podName string, rFailover *redisfailoverv1.RedisFailover) (string, error)
+	CheckRedisSyncing(slaveIP string, rFailover *redisfailoverv1.RedisFailover) (bool, error)
 }
 
 // RedisFailoverChecker is our implementation of RedisFailoverCheck interface
@@ -229,4 +235,102 @@ func (r *RedisFailoverChecker) GetMinimumRedisPodTime(rf *redisfailoverv1.RedisF
 		}
 	}
 	return minTime, nil
+}
+
+// GetRedisesSlavesPods returns pods names of the Redis slave nodes
+func (r *RedisFailoverChecker) GetRedisesSlavesPods(rf *redisfailoverv1.RedisFailover) ([]string, error) {
+	redises := []string{}
+	rps, err := r.k8sService.GetStatefulSetPods(rf.Namespace, GetRedisName(rf))
+	if err != nil {
+		return nil, err
+	}
+
+	password, err := k8s.GetRedisPassword(r.k8sService, rf)
+	if err != nil {
+		return redises, err
+	}
+
+	for _, rp := range rps.Items {
+		if rp.Status.Phase == corev1.PodRunning { // Only work with running
+			master, err := r.redisClient.IsMaster(rp.Status.PodIP, password)
+			if err != nil {
+				return []string{}, err
+			}
+			if !master {
+				redises = append(redises, rp.ObjectMeta.Name)
+			}
+		}
+	}
+	return redises, nil
+}
+
+// GetRedisesMasterPod returns pods names of the Redis slave nodes
+func (r *RedisFailoverChecker) GetRedisesMasterPod(rFailover *redisfailoverv1.RedisFailover) (string, error) {
+	rps, err := r.k8sService.GetStatefulSetPods(rFailover.Namespace, GetRedisName(rFailover))
+	if err != nil {
+		return "", err
+	}
+
+	password, err := k8s.GetRedisPassword(r.k8sService, rFailover)
+	if err != nil {
+		return "", err
+	}
+
+	for _, rp := range rps.Items {
+		if rp.Status.Phase == corev1.PodRunning { // Only work with running
+			master, err := r.redisClient.IsMaster(rp.Status.PodIP, password)
+			if err != nil {
+				return "", err
+			}
+			if master {
+				return rp.ObjectMeta.Name, nil
+			}
+		}
+	}
+	return "", errors.New("redis nodes known as master not found")
+}
+
+// GetStatefulSetUpdateRevision returns current version for the statefulSet
+// If the label don't exists, we return an empty value and no error, so previous versions don't break
+func (r *RedisFailoverChecker) GetStatefulSetUpdateRevision(rFailover *redisfailoverv1.RedisFailover) (string, error) {
+	ss, err := r.k8sService.GetStatefulSet(rFailover.Namespace, GetRedisName(rFailover))
+	if err != nil {
+		return "", err
+	}
+
+	if ss == nil {
+		return "", errors.New("statefulSet not found")
+	}
+
+	return ss.Status.UpdateRevision, nil
+}
+
+// GetRedisRevisionHash returns the statefulset uid for the pod
+func (r *RedisFailoverChecker) GetRedisRevisionHash(podName string, rFailover *redisfailoverv1.RedisFailover) (string, error) {
+	pod, err := r.k8sService.GetPod(rFailover.Namespace, podName)
+	if err != nil {
+		return "", err
+	}
+
+	if pod == nil {
+		return "", errors.New("pod not found")
+	}
+
+	if pod.ObjectMeta.Labels == nil {
+		return "", errors.New("labels not found")
+	}
+
+	val, _ := pod.ObjectMeta.Labels[appsv1.ControllerRevisionHashLabelKey]
+
+	return val, nil
+}
+
+// CheckRedisSyncing returns true if the slave is still syncing
+func (r *RedisFailoverChecker) CheckRedisSyncing(ip string, rFailover *redisfailoverv1.RedisFailover) (bool, error) {
+	password, err := k8s.GetRedisPassword(r.k8sService, rFailover)
+	if err != nil {
+		return false, err
+	}
+
+	return r.redisClient.IsSyncing(ip, password)
 }

--- a/operator/redisfailover/service/generator.go
+++ b/operator/redisfailover/service/generator.go
@@ -180,7 +180,7 @@ func generateRedisStatefulSet(rf *redisfailoverv1.RedisFailover, labels map[stri
 			ServiceName: name,
 			Replicas:    &rf.Spec.Redis.Replicas,
 			UpdateStrategy: appsv1.StatefulSetUpdateStrategy{
-				Type: "RollingUpdate",
+				Type: "OnDelete",
 			},
 			Selector: &metav1.LabelSelector{
 				MatchLabels: selectorLabels,

--- a/operator/redisfailover/service/heal.go
+++ b/operator/redisfailover/service/heal.go
@@ -20,6 +20,7 @@ type RedisFailoverHeal interface {
 	RestoreSentinel(ip string) error
 	SetSentinelCustomConfig(ip string, rFailover *redisfailoverv1.RedisFailover) error
 	SetRedisCustomConfig(ip string, rFailover *redisfailoverv1.RedisFailover) error
+	DeletePod(podName string, rFailover *redisfailoverv1.RedisFailover) error
 }
 
 // RedisFailoverHealer is our implementation of RedisFailoverCheck interface
@@ -148,4 +149,10 @@ func (r *RedisFailoverHealer) SetRedisCustomConfig(ip string, rf *redisfailoverv
 	}
 
 	return r.redisClient.SetCustomRedisConfig(ip, rf.Spec.Redis.CustomConfig, password)
+}
+
+//DeletePod delete a failing pod so kubernetes relaunch it again
+func (r *RedisFailoverHealer) DeletePod(podName string, rFailover *redisfailoverv1.RedisFailover) error {
+	r.logger.Debugf("Deleting pods %s...", podName)
+	return r.k8sService.DeletePod(rFailover.Namespace, podName)
 }


### PR DESCRIPTION
- Until now, we rely in kubernetes to update the pods when changes are introduced in the stateful set.
-This can lead to problems, as the master can be relaunch when the new slave pods are still syncing
-So now the controller takes the update task, killing pod-by-pod and only when the syncing in all slaves is done.