### PR TITLE
change readiness probe

### DIFF
--- a/mocks/operator/redisfailover/service/RedisFailoverClient.go
+++ b/mocks/operator/redisfailover/service/RedisFailoverClient.go
@@ -42,6 +42,20 @@ func (_m *RedisFailoverClient) EnsureRedisConfigMap(rFailover *v1.RedisFailover,
 	return r0
 }
 
+// EnsureRedisReadinessConfigMap provides a mock function with given fields: rFailover, labels, ownerRefs
+func (_m *RedisFailoverClient) EnsureRedisReadinessConfigMap(rFailover *v1.RedisFailover, labels map[string]string, ownerRefs []metav1.OwnerReference) error {
+	ret := _m.Called(rFailover, labels, ownerRefs)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(*v1.RedisFailover, map[string]string, []metav1.OwnerReference) error); ok {
+		r0 = rf(rFailover, labels, ownerRefs)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 // EnsureRedisService provides a mock function with given fields: rFailover, labels, ownerRefs
 func (_m *RedisFailoverClient) EnsureRedisService(rFailover *v1.RedisFailover, labels map[string]string, ownerRefs []metav1.OwnerReference) error {
 	ret := _m.Called(rFailover, labels, ownerRefs)

--- a/operator/redisfailover/ensurer.go
+++ b/operator/redisfailover/ensurer.go
@@ -25,6 +25,9 @@ func (w *RedisFailoverHandler) Ensure(rf *redisfailoverv1.RedisFailover, labels 
 	if err := w.rfService.EnsureRedisShutdownConfigMap(rf, labels, or); err != nil {
 		return err
 	}
+	if err := w.rfService.EnsureRedisReadinessConfigMap(rf, labels, or); err != nil {
+		return err
+	}
 	if err := w.rfService.EnsureRedisConfigMap(rf, labels, or); err != nil {
 		return err
 	}

--- a/operator/redisfailover/ensurer_test.go
+++ b/operator/redisfailover/ensurer_test.go
@@ -86,6 +86,7 @@ func TestEnsure(t *testing.T) {
 			mrfs.On("EnsureSentinelConfigMap", rf, mock.Anything, mock.Anything).Once().Return(nil)
 			mrfs.On("EnsureRedisConfigMap", rf, mock.Anything, mock.Anything).Once().Return(nil)
 			mrfs.On("EnsureRedisShutdownConfigMap", rf, mock.Anything, mock.Anything).Once().Return(nil)
+			mrfs.On("EnsureRedisReadinessConfigMap", rf, mock.Anything, mock.Anything).Once().Return(nil)
 			mrfs.On("EnsureRedisStatefulset", rf, mock.Anything, mock.Anything).Once().Return(nil)
 			mrfs.On("EnsureSentinelDeployment", rf, mock.Anything, mock.Anything).Once().Return(nil)
 

--- a/operator/redisfailover/service/client.go
+++ b/operator/redisfailover/service/client.go
@@ -19,6 +19,7 @@ type RedisFailoverClient interface {
 	EnsureRedisStatefulset(rFailover *redisfailoverv1.RedisFailover, labels map[string]string, ownerRefs []metav1.OwnerReference) error
 	EnsureRedisService(rFailover *redisfailoverv1.RedisFailover, labels map[string]string, ownerRefs []metav1.OwnerReference) error
 	EnsureRedisShutdownConfigMap(rFailover *redisfailoverv1.RedisFailover, labels map[string]string, ownerRefs []metav1.OwnerReference) error
+	EnsureRedisReadinessConfigMap(rFailover *redisfailoverv1.RedisFailover, labels map[string]string, ownerRefs []metav1.OwnerReference) error
 	EnsureRedisConfigMap(rFailover *redisfailoverv1.RedisFailover, labels map[string]string, ownerRefs []metav1.OwnerReference) error
 	EnsureNotPresentRedisService(rFailover *redisfailoverv1.RedisFailover) error
 }
@@ -98,6 +99,12 @@ func (r *RedisFailoverKubeClient) EnsureRedisShutdownConfigMap(rf *redisfailover
 		return r.K8SService.CreateOrUpdateConfigMap(rf.Namespace, cm)
 	}
 	return nil
+}
+
+// EnsureRedisReadinessConfigMap makes sure the redis configmap with shutdown script exists
+func (r *RedisFailoverKubeClient) EnsureRedisReadinessConfigMap(rf *redisfailoverv1.RedisFailover, labels map[string]string, ownerRefs []metav1.OwnerReference) error {
+	cm := generateRedisReadinessConfigMap(rf, labels, ownerRefs)
+	return r.K8SService.CreateOrUpdateConfigMap(rf.Namespace, cm)
 }
 
 // EnsureRedisService makes sure the redis statefulset exists

--- a/operator/redisfailover/service/constants.go
+++ b/operator/redisfailover/service/constants.go
@@ -26,6 +26,7 @@ const (
 	redisConfigFileName    = "redis.conf"
 	redisName              = "r"
 	redisShutdownName      = "r-s"
+	redisReadinessName     = "r-readiness"
 	redisRoleName          = "redis"
 	redisGroupName         = "mymaster"
 	appLabel               = "redis-failover"

--- a/operator/redisfailover/service/generator.go
+++ b/operator/redisfailover/service/generator.go
@@ -17,6 +17,7 @@ import (
 const (
 	redisConfigurationVolumeName         = "redis-config"
 	redisShutdownConfigurationVolumeName = "redis-shutdown-config"
+	redisReadinessVolumeName             = "redis-readiness-config"
 	redisStorageVolumeName               = "redis-data"
 
 	graceTime = 30
@@ -158,6 +159,58 @@ fi`
 		},
 	}
 }
+func generateRedisReadinessConfigMap(rf *redisfailoverv1.RedisFailover, labels map[string]string, ownerRefs []metav1.OwnerReference) *corev1.ConfigMap {
+	name := GetRedisReadinessName(rf)
+	namespace := rf.Namespace
+
+	labels = util.MergeLabels(labels, generateSelectorLabels(redisRoleName, rf.Name))
+	readinessContent := `ROLE="role"
+   ROLE_MASTER="role:master"
+   ROLE_SLAVE="role:slave"
+   IN_SYNC="master_sync_in_progress:1"
+   NO_MASTER="master_host:127.0.0.1"
+   
+   check_master(){
+           exit 0
+   }
+   
+   check_slave(){
+           in_sync=$(redis-cli info replication | grep $IN_SYNC | tr -d "\r" | tr -d "\n")
+           no_master=$(redis-cli info replication | grep $NO_MASTER | tr -d "\r" | tr -d "\n")
+   
+           if [ -z "$in_sync" ] && [ -z "$no_master" ]; then
+                   exit 0
+           fi
+   
+           exit 1
+   }
+   
+   role=$(redis-cli info replication | grep $ROLE | tr -d "\r" | tr -d "\n")
+   
+   case $role in
+           $ROLE_MASTER)
+                   check_master
+                   ;;
+           $ROLE_SLAVE)
+                   check_slave
+                   ;;
+           *)
+                   echo "unespected"
+                   exit 1
+   esac`
+
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            name,
+			Namespace:       namespace,
+			Labels:          labels,
+			OwnerReferences: ownerRefs,
+		},
+		Data: map[string]string{
+			"ready.sh": readinessContent,
+		},
+	}
+}
 
 func generateRedisStatefulSet(rf *redisfailoverv1.RedisFailover, labels map[string]string, ownerRefs []metav1.OwnerReference) *appsv1.StatefulSet {
 	name := GetRedisName(rf)
@@ -191,10 +244,10 @@ func generateRedisStatefulSet(rf *redisfailoverv1.RedisFailover, labels map[stri
 					Annotations: rf.Spec.Redis.PodAnnotations,
 				},
 				Spec: corev1.PodSpec{
-					Affinity:        getAffinity(rf.Spec.Redis.Affinity, labels),
-					Tolerations:     rf.Spec.Redis.Tolerations,
-					NodeSelector:    rf.Spec.Redis.NodeSelector,
-					SecurityContext: getSecurityContext(rf.Spec.Redis.SecurityContext),
+					Affinity:         getAffinity(rf.Spec.Redis.Affinity, labels),
+					Tolerations:      rf.Spec.Redis.Tolerations,
+					NodeSelector:     rf.Spec.Redis.NodeSelector,
+					SecurityContext:  getSecurityContext(rf.Spec.Redis.SecurityContext),
 					ImagePullSecrets: rf.Spec.Redis.ImagePullSecrets,
 					Containers: []corev1.Container{
 						{
@@ -215,11 +268,7 @@ func generateRedisStatefulSet(rf *redisfailoverv1.RedisFailover, labels map[stri
 								TimeoutSeconds:      5,
 								Handler: corev1.Handler{
 									Exec: &corev1.ExecAction{
-										Command: []string{
-											"sh",
-											"-c",
-											"redis-cli -h $(hostname) ping",
-										},
+										Command: []string{"/bin/sh", "/redis-readiness/ready.sh"},
 									},
 								},
 							},
@@ -297,10 +346,10 @@ func generateSentinelDeployment(rf *redisfailoverv1.RedisFailover, labels map[st
 					Annotations: rf.Spec.Sentinel.PodAnnotations,
 				},
 				Spec: corev1.PodSpec{
-					Affinity:        getAffinity(rf.Spec.Sentinel.Affinity, labels),
-					Tolerations:     rf.Spec.Sentinel.Tolerations,
-					NodeSelector:    rf.Spec.Sentinel.NodeSelector,
-					SecurityContext: getSecurityContext(rf.Spec.Sentinel.SecurityContext),
+					Affinity:         getAffinity(rf.Spec.Sentinel.Affinity, labels),
+					Tolerations:      rf.Spec.Sentinel.Tolerations,
+					NodeSelector:     rf.Spec.Sentinel.NodeSelector,
+					SecurityContext:  getSecurityContext(rf.Spec.Sentinel.SecurityContext),
 					ImagePullSecrets: rf.Spec.Sentinel.ImagePullSecrets,
 					InitContainers: []corev1.Container{
 						{
@@ -539,6 +588,10 @@ func getRedisVolumeMounts(rf *redisfailoverv1.RedisFailover) []corev1.VolumeMoun
 			MountPath: "/redis-shutdown",
 		},
 		{
+			Name:      redisReadinessVolumeName,
+			MountPath: "/redis-readiness",
+		},
+		{
 			Name:      getRedisDataVolumeName(rf),
 			MountPath: "/data",
 		},
@@ -550,6 +603,7 @@ func getRedisVolumeMounts(rf *redisfailoverv1.RedisFailover) []corev1.VolumeMoun
 func getRedisVolumes(rf *redisfailoverv1.RedisFailover) []corev1.Volume {
 	configMapName := GetRedisName(rf)
 	shutdownConfigMapName := GetRedisShutdownConfigMapName(rf)
+	readinessConfigMapName := GetRedisReadinessName(rf)
 
 	executeMode := int32(0744)
 	volumes := []corev1.Volume{
@@ -569,6 +623,17 @@ func getRedisVolumes(rf *redisfailoverv1.RedisFailover) []corev1.Volume {
 				ConfigMap: &corev1.ConfigMapVolumeSource{
 					LocalObjectReference: corev1.LocalObjectReference{
 						Name: shutdownConfigMapName,
+					},
+					DefaultMode: &executeMode,
+				},
+			},
+		},
+		{
+			Name: redisReadinessVolumeName,
+			VolumeSource: corev1.VolumeSource{
+				ConfigMap: &corev1.ConfigMapVolumeSource{
+					LocalObjectReference: corev1.LocalObjectReference{
+						Name: readinessConfigMapName,
 					},
 					DefaultMode: &executeMode,
 				},

--- a/operator/redisfailover/service/generator.go
+++ b/operator/redisfailover/service/generator.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	appsv1 "k8s.io/api/apps/v1"
+	v1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	policyv1beta1 "k8s.io/api/policy/v1beta1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -233,8 +234,9 @@ func generateRedisStatefulSet(rf *redisfailoverv1.RedisFailover, labels map[stri
 			ServiceName: name,
 			Replicas:    &rf.Spec.Redis.Replicas,
 			UpdateStrategy: appsv1.StatefulSetUpdateStrategy{
-				Type: "OnDelete",
+				Type: v1.OnDeleteStatefulSetStrategyType,
 			},
+			PodManagementPolicy: v1.ParallelPodManagement,
 			Selector: &metav1.LabelSelector{
 				MatchLabels: selectorLabels,
 			},

--- a/operator/redisfailover/service/generator_test.go
+++ b/operator/redisfailover/service/generator_test.go
@@ -19,6 +19,7 @@ import (
 func TestRedisStatefulSetStorageGeneration(t *testing.T) {
 	configMapName := rfservice.GetRedisName(generateRF())
 	shutdownConfigMapName := rfservice.GetRedisShutdownConfigMapName(generateRF())
+	readinesConfigMapName := rfservice.GetRedisReadinessName(generateRF())
 	executeMode := int32(0744)
 	tests := []struct {
 		name           string
@@ -44,6 +45,10 @@ func TestRedisStatefulSetStorageGeneration(t *testing.T) {
 											MountPath: "/redis-shutdown",
 										},
 										{
+											Name:      "redis-readiness-config",
+											MountPath: "/redis-readiness",
+										},
+										{
 											Name:      "redis-data",
 											MountPath: "/data",
 										},
@@ -67,6 +72,17 @@ func TestRedisStatefulSetStorageGeneration(t *testing.T) {
 										ConfigMap: &corev1.ConfigMapVolumeSource{
 											LocalObjectReference: corev1.LocalObjectReference{
 												Name: shutdownConfigMapName,
+											},
+											DefaultMode: &executeMode,
+										},
+									},
+								},
+								{
+									Name: "redis-readiness-config",
+									VolumeSource: corev1.VolumeSource{
+										ConfigMap: &corev1.ConfigMapVolumeSource{
+											LocalObjectReference: corev1.LocalObjectReference{
+												Name: readinesConfigMapName,
 											},
 											DefaultMode: &executeMode,
 										},
@@ -103,6 +119,10 @@ func TestRedisStatefulSetStorageGeneration(t *testing.T) {
 											MountPath: "/redis-shutdown",
 										},
 										{
+											Name:      "redis-readiness-config",
+											MountPath: "/redis-readiness",
+										},
+										{
 											Name:      "redis-data",
 											MountPath: "/data",
 										},
@@ -126,6 +146,17 @@ func TestRedisStatefulSetStorageGeneration(t *testing.T) {
 										ConfigMap: &corev1.ConfigMapVolumeSource{
 											LocalObjectReference: corev1.LocalObjectReference{
 												Name: shutdownConfigMapName,
+											},
+											DefaultMode: &executeMode,
+										},
+									},
+								},
+								{
+									Name: "redis-readiness-config",
+									VolumeSource: corev1.VolumeSource{
+										ConfigMap: &corev1.ConfigMapVolumeSource{
+											LocalObjectReference: corev1.LocalObjectReference{
+												Name: readinesConfigMapName,
 											},
 											DefaultMode: &executeMode,
 										},
@@ -168,6 +199,10 @@ func TestRedisStatefulSetStorageGeneration(t *testing.T) {
 											MountPath: "/redis-shutdown",
 										},
 										{
+											Name:      "redis-readiness-config",
+											MountPath: "/redis-readiness",
+										},
+										{
 											Name:      "pvc-data",
 											MountPath: "/data",
 										},
@@ -191,6 +226,17 @@ func TestRedisStatefulSetStorageGeneration(t *testing.T) {
 										ConfigMap: &corev1.ConfigMapVolumeSource{
 											LocalObjectReference: corev1.LocalObjectReference{
 												Name: shutdownConfigMapName,
+											},
+											DefaultMode: &executeMode,
+										},
+									},
+								},
+								{
+									Name: "redis-readiness-config",
+									VolumeSource: corev1.VolumeSource{
+										ConfigMap: &corev1.ConfigMapVolumeSource{
+											LocalObjectReference: corev1.LocalObjectReference{
+												Name: readinesConfigMapName,
 											},
 											DefaultMode: &executeMode,
 										},
@@ -259,6 +305,10 @@ func TestRedisStatefulSetStorageGeneration(t *testing.T) {
 											MountPath: "/redis-shutdown",
 										},
 										{
+											Name:      "redis-readiness-config",
+											MountPath: "/redis-readiness",
+										},
+										{
 											Name:      "pvc-data",
 											MountPath: "/data",
 										},
@@ -282,6 +332,17 @@ func TestRedisStatefulSetStorageGeneration(t *testing.T) {
 										ConfigMap: &corev1.ConfigMapVolumeSource{
 											LocalObjectReference: corev1.LocalObjectReference{
 												Name: shutdownConfigMapName,
+											},
+											DefaultMode: &executeMode,
+										},
+									},
+								},
+								{
+									Name: "redis-readiness-config",
+									VolumeSource: corev1.VolumeSource{
+										ConfigMap: &corev1.ConfigMapVolumeSource{
+											LocalObjectReference: corev1.LocalObjectReference{
+												Name: readinesConfigMapName,
 											},
 											DefaultMode: &executeMode,
 										},
@@ -355,6 +416,10 @@ func TestRedisStatefulSetStorageGeneration(t *testing.T) {
 											MountPath: "/redis-shutdown",
 										},
 										{
+											Name:      "redis-readiness-config",
+											MountPath: "/redis-readiness",
+										},
+										{
 											Name:      "pvc-data",
 											MountPath: "/data",
 										},
@@ -378,6 +443,17 @@ func TestRedisStatefulSetStorageGeneration(t *testing.T) {
 										ConfigMap: &corev1.ConfigMapVolumeSource{
 											LocalObjectReference: corev1.LocalObjectReference{
 												Name: shutdownConfigMapName,
+											},
+											DefaultMode: &executeMode,
+										},
+									},
+								},
+								{
+									Name: "redis-readiness-config",
+									VolumeSource: corev1.VolumeSource{
+										ConfigMap: &corev1.ConfigMapVolumeSource{
+											LocalObjectReference: corev1.LocalObjectReference{
+												Name: readinesConfigMapName,
 											},
 											DefaultMode: &executeMode,
 										},

--- a/operator/redisfailover/service/names.go
+++ b/operator/redisfailover/service/names.go
@@ -24,6 +24,11 @@ func GetRedisShutdownName(rf *redisfailoverv1.RedisFailover) string {
 	return generateName(redisShutdownName, rf.Name)
 }
 
+// GetRedisReadinessName returns the name for redis resources
+func GetRedisReadinessName(rf *redisfailoverv1.RedisFailover) string {
+	return generateName(redisReadinessName, rf.Name)
+}
+
 // GetSentinelName returns the name for sentinel resources
 func GetSentinelName(rf *redisfailoverv1.RedisFailover) string {
 	return generateName(sentinelName, rf.Name)


### PR DESCRIPTION
Fixes # .

Changes proposed on the PR:
- Change the readiness probe to check not only the service is up, but also if the slave is connected to master and the synchronization process is ended
