### PR TITLE
add secrets to rbac role permissions

### DIFF
--- a/example/operator/roles.yaml
+++ b/example/operator/roles.yaml
@@ -23,6 +23,7 @@ rules:
       - endpoints
       - events
       - configmaps
+      - secrets
     verbs:
       - "*"
   - apiGroups:


### PR DESCRIPTION
This should have been a part of #186 

Changes proposed on the PR:
- adds secrets to rbac role example 