### PR TITLE
Add fsGroup to security context

### DIFF
--- a/operator/redisfailover/service/generator.go
+++ b/operator/redisfailover/service/generator.go
@@ -607,6 +607,7 @@ func getSecurityContext(secctx *corev1.PodSecurityContext) *corev1.PodSecurityCo
 		RunAsUser:    &defaultUserAndGroup,
 		RunAsGroup:   &defaultUserAndGroup,
 		RunAsNonRoot: &runAsNonRoot,
+		FSGroup:      &defaultUserAndGroup,
 	}
 }
 


### PR DESCRIPTION
Since container is run as userId 1000 attached volume needs to be accesible by redis when persistence is enabled