### PR TITLE
make qps and burst configurable

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -8,11 +8,6 @@ import (
 	"k8s.io/client-go/util/homedir"
 )
 
-const (
-	defCliQPS   = 100
-	defCliBurst = 100
-)
-
 // CMDFlags are the flags used by the cmd
 // TODO: improve flags.
 type CMDFlags struct {
@@ -21,8 +16,6 @@ type CMDFlags struct {
 	Debug       bool
 	ListenAddr  string
 	MetricsPath string
-	CliQPS      float64
-	CliBurst    int
 }
 
 // Init initializes and parse the flags
@@ -34,8 +27,6 @@ func (c *CMDFlags) Init() {
 	flag.BoolVar(&c.Debug, "debug", false, "enable debug mode")
 	flag.StringVar(&c.ListenAddr, "listen-address", ":9710", "Address to listen on for metrics.")
 	flag.StringVar(&c.MetricsPath, "metrics-path", "/metrics", "Path to serve the metrics.")
-	flag.Float64Var(&c.CliQPS, "cli-qps", defCliQPS, "QPS value for kubernetes client.")
-	flag.IntVar(&c.CliBurst, "cli-burst", defCliBurst, "Burst value for kubernetes client.")
 
 	// Parse flags
 	flag.Parse()

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -8,6 +8,11 @@ import (
 	"k8s.io/client-go/util/homedir"
 )
 
+const (
+	defCliQPS   = 100
+	defCliBurst = 100
+)
+
 // CMDFlags are the flags used by the cmd
 // TODO: improve flags.
 type CMDFlags struct {
@@ -16,6 +21,8 @@ type CMDFlags struct {
 	Debug       bool
 	ListenAddr  string
 	MetricsPath string
+	CliQPS      float64
+	CliBurst    int
 }
 
 // Init initializes and parse the flags
@@ -27,6 +34,8 @@ func (c *CMDFlags) Init() {
 	flag.BoolVar(&c.Debug, "debug", false, "enable debug mode")
 	flag.StringVar(&c.ListenAddr, "listen-address", ":9710", "Address to listen on for metrics.")
 	flag.StringVar(&c.MetricsPath, "metrics-path", "/metrics", "Path to serve the metrics.")
+	flag.Float64Var(&c.CliQPS, "cli-qps", defCliQPS, "QPS value for kubernetes client.")
+	flag.IntVar(&c.CliBurst, "cli-burst", defCliBurst, "Burst value for kubernetes client.")
 
 	// Parse flags
 	flag.Parse()

--- a/cmd/utils/k8s.go
+++ b/cmd/utils/k8s.go
@@ -29,6 +29,9 @@ func LoadKubernetesConfig(flags *CMDFlags) (*rest.Config, error) {
 		cfg = config
 	}
 
+	cfg.QPS = float32(flags.CliQPS)
+	cfg.Burst = flags.CliBurst
+
 	return cfg, nil
 }
 

--- a/cmd/utils/k8s.go
+++ b/cmd/utils/k8s.go
@@ -11,6 +11,11 @@ import (
 	redisfailoverclientset "github.com/spotahome/redis-operator/client/k8s/clientset/versioned"
 )
 
+const (
+	defCliQPS   = 100
+	defCliBurst = 100
+)
+
 // LoadKubernetesConfig loads kubernetes configuration based on flags.
 func LoadKubernetesConfig(flags *CMDFlags) (*rest.Config, error) {
 	var cfg *rest.Config
@@ -29,8 +34,8 @@ func LoadKubernetesConfig(flags *CMDFlags) (*rest.Config, error) {
 		cfg = config
 	}
 
-	cfg.QPS = float32(flags.CliQPS)
-	cfg.Burst = flags.CliBurst
+	cfg.QPS = defCliQPS
+	cfg.Burst = defCliBurst
 
 	return cfg, nil
 }


### PR DESCRIPTION
When the number of resources grows, the default QPS and burst values can be too low to manage them. This PR make both configurable and also change the default values. 