### PR TITLE
219/custom annotations for services

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,11 @@ By default, no pod annotations will be applied to Redis nor Sentinel pods.
 
 In order to apply custom pod Annotations, you can provide the `podAnnotations` option inside redis/sentinel spec. An example can be found in the [custom annotations example file](example/redisfailover/custom-annotations.yaml).
 
+### Custom Service Annotations
+By default, no service annotations will be applied to the Redis nor Sentinel services.
+
+In order to apply custom service Annotations, you can provide the `serviceAnnotations` option inside redis/sentinel spec. An example can be found in the [custom annotations example file](example/redisfailover/custom-annotations.yaml).
+
 ### Control of label propagation.
 By default the operator will propagate all labels on the CRD down to the resources that it creates.  This can be problematic if the
 labels on the CRD are not fully under your own control (for example: being deployed by a gitops operator)

--- a/api/redisfailover/v1/types.go
+++ b/api/redisfailover/v1/types.go
@@ -17,10 +17,10 @@ type RedisFailover struct {
 
 // RedisFailoverSpec represents a Redis failover spec
 type RedisFailoverSpec struct {
-	Redis    RedisSettings    `json:"redis,omitempty"`
-	Sentinel SentinelSettings `json:"sentinel,omitempty"`
-	Auth     AuthSettings     `json:"auth,omitempty"`
-	LabelWhitelist []string   `json:"labelWhitelist,omitempty"`
+	Redis          RedisSettings    `json:"redis,omitempty"`
+	Sentinel       SentinelSettings `json:"sentinel,omitempty"`
+	Auth           AuthSettings     `json:"auth,omitempty"`
+	LabelWhitelist []string         `json:"labelWhitelist,omitempty"`
 }
 
 // RedisSettings defines the specification of the redis cluster
@@ -46,21 +46,22 @@ type RedisSettings struct {
 
 // SentinelSettings defines the specification of the sentinel cluster
 type SentinelSettings struct {
-	Image            string                        `json:"image,omitempty"`
-	ImagePullPolicy  corev1.PullPolicy             `json:"imagePullPolicy,omitempty"`
-	Replicas         int32                         `json:"replicas,omitempty"`
-	Resources        corev1.ResourceRequirements   `json:"resources,omitempty"`
-	CustomConfig     []string                      `json:"customConfig,omitempty"`
-	Command          []string                      `json:"command,omitempty"`
-	Affinity         *corev1.Affinity              `json:"affinity,omitempty"`
-	SecurityContext  *corev1.PodSecurityContext    `json:"securityContext,omitempty"`
-	ImagePullSecrets []corev1.LocalObjectReference `json:"imagePullSecrets,omitempty"`
-	Tolerations      []corev1.Toleration           `json:"tolerations,omitempty"`
-	NodeSelector     map[string]string             `json:"nodeSelector,omitempty"`
-	PodAnnotations   map[string]string             `json:"podAnnotations,omitempty"`
-	Exporter         SentinelExporter              `json:"exporter,omitempty"`
-	HostNetwork      bool                          `json:"hostNetwork,omitempty"`
-	DNSPolicy        corev1.DNSPolicy              `json:"dnsPolicy,omitempty"`
+	Image              string                        `json:"image,omitempty"`
+	ImagePullPolicy    corev1.PullPolicy             `json:"imagePullPolicy,omitempty"`
+	Replicas           int32                         `json:"replicas,omitempty"`
+	Resources          corev1.ResourceRequirements   `json:"resources,omitempty"`
+	CustomConfig       []string                      `json:"customConfig,omitempty"`
+	Command            []string                      `json:"command,omitempty"`
+	Affinity           *corev1.Affinity              `json:"affinity,omitempty"`
+	SecurityContext    *corev1.PodSecurityContext    `json:"securityContext,omitempty"`
+	ImagePullSecrets   []corev1.LocalObjectReference `json:"imagePullSecrets,omitempty"`
+	Tolerations        []corev1.Toleration           `json:"tolerations,omitempty"`
+	NodeSelector       map[string]string             `json:"nodeSelector,omitempty"`
+	PodAnnotations     map[string]string             `json:"podAnnotations,omitempty"`
+	ServiceAnnotations map[string]string             `json:"serviceAnnotations,omitempty"`
+	Exporter           SentinelExporter              `json:"exporter,omitempty"`
+	HostNetwork        bool                          `json:"hostNetwork,omitempty"`
+	DNSPolicy          corev1.DNSPolicy              `json:"dnsPolicy,omitempty"`
 }
 
 // AuthSettings contains settings about auth

--- a/api/redisfailover/v1/types.go
+++ b/api/redisfailover/v1/types.go
@@ -25,23 +25,24 @@ type RedisFailoverSpec struct {
 
 // RedisSettings defines the specification of the redis cluster
 type RedisSettings struct {
-	Image             string                        `json:"image,omitempty"`
-	ImagePullPolicy   corev1.PullPolicy             `json:"imagePullPolicy,omitempty"`
-	Replicas          int32                         `json:"replicas,omitempty"`
-	Resources         corev1.ResourceRequirements   `json:"resources,omitempty"`
-	CustomConfig      []string                      `json:"customConfig,omitempty"`
-	Command           []string                      `json:"command,omitempty"`
-	ShutdownConfigMap string                        `json:"shutdownConfigMap,omitempty"`
-	Storage           RedisStorage                  `json:"storage,omitempty"`
-	Exporter          RedisExporter                 `json:"exporter,omitempty"`
-	Affinity          *corev1.Affinity              `json:"affinity,omitempty"`
-	SecurityContext   *corev1.PodSecurityContext    `json:"securityContext,omitempty"`
-	ImagePullSecrets  []corev1.LocalObjectReference `json:"imagePullSecrets,omitempty"`
-	Tolerations       []corev1.Toleration           `json:"tolerations,omitempty"`
-	NodeSelector      map[string]string             `json:"nodeSelector,omitempty"`
-	PodAnnotations    map[string]string             `json:"podAnnotations,omitempty"`
-	HostNetwork       bool                          `json:"hostNetwork,omitempty"`
-	DNSPolicy         corev1.DNSPolicy              `json:"dnsPolicy,omitempty"`
+	Image              string                        `json:"image,omitempty"`
+	ImagePullPolicy    corev1.PullPolicy             `json:"imagePullPolicy,omitempty"`
+	Replicas           int32                         `json:"replicas,omitempty"`
+	Resources          corev1.ResourceRequirements   `json:"resources,omitempty"`
+	CustomConfig       []string                      `json:"customConfig,omitempty"`
+	Command            []string                      `json:"command,omitempty"`
+	ShutdownConfigMap  string                        `json:"shutdownConfigMap,omitempty"`
+	Storage            RedisStorage                  `json:"storage,omitempty"`
+	Exporter           RedisExporter                 `json:"exporter,omitempty"`
+	Affinity           *corev1.Affinity              `json:"affinity,omitempty"`
+	SecurityContext    *corev1.PodSecurityContext    `json:"securityContext,omitempty"`
+	ImagePullSecrets   []corev1.LocalObjectReference `json:"imagePullSecrets,omitempty"`
+	Tolerations        []corev1.Toleration           `json:"tolerations,omitempty"`
+	NodeSelector       map[string]string             `json:"nodeSelector,omitempty"`
+	PodAnnotations     map[string]string             `json:"podAnnotations,omitempty"`
+	ServiceAnnotations map[string]string             `json:"serviceAnnotations,omitempty"`
+	HostNetwork        bool                          `json:"hostNetwork,omitempty"`
+	DNSPolicy          corev1.DNSPolicy              `json:"dnsPolicy,omitempty"`
 }
 
 // SentinelSettings defines the specification of the sentinel cluster

--- a/example/redisfailover/custom-annotations.yaml
+++ b/example/redisfailover/custom-annotations.yaml
@@ -7,7 +7,11 @@ spec:
     replicas: 3
     podAnnotations:
       imageregistry: "https://hub.docker.com/"
+    serviceAnnotations:
+      imageregistry: "https://hub.docker.com/"
   redis:
     replicas: 3
     podAnnotations:
+      imageregistry: "https://hub.docker.com/"
+    serviceAnnotations:
       imageregistry: "https://hub.docker.com/"

--- a/operator/redisfailover/service/generator_test.go
+++ b/operator/redisfailover/service/generator_test.go
@@ -9,6 +9,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 
 	redisfailoverv1 "github.com/spotahome/redis-operator/api/redisfailover/v1"
 	"github.com/spotahome/redis-operator/log"
@@ -725,6 +726,472 @@ func TestSentinelDeploymentPodAnnotations(t *testing.T) {
 
 		assert.Equal(test.expectedPodAnnotations, gotPodAnnotations)
 		assert.NoError(err)
+	}
+}
+
+func TestSentinelService(t *testing.T) {
+	tests := []struct {
+		name            string
+		rfName          string
+		rfNamespace     string
+		rfLabels        map[string]string
+		rfAnnotations   map[string]string
+		expectedService corev1.Service
+	}{
+		{
+			name: "with defaults",
+			expectedService: corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      sentinelName,
+					Namespace: namespace,
+					Labels: map[string]string{
+						"app.kubernetes.io/component": "sentinel",
+						"app.kubernetes.io/name":      name,
+						"app.kubernetes.io/part-of":   "redis-failover",
+					},
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							Name: "testing",
+						},
+					},
+				},
+				Spec: corev1.ServiceSpec{
+					Selector: map[string]string{
+						"app.kubernetes.io/component": "sentinel",
+						"app.kubernetes.io/name":      name,
+						"app.kubernetes.io/part-of":   "redis-failover",
+					},
+					Ports: []corev1.ServicePort{
+						{
+							Name:       "sentinel",
+							Port:       26379,
+							TargetPort: intstr.FromInt(26379),
+							Protocol:   "TCP",
+						},
+					},
+				},
+			},
+		},
+		{
+			name:   "with Name provided",
+			rfName: "custom-name",
+			expectedService: corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "rfs-custom-name",
+					Namespace: namespace,
+					Labels: map[string]string{
+						"app.kubernetes.io/component": "sentinel",
+						"app.kubernetes.io/name":      "custom-name",
+						"app.kubernetes.io/part-of":   "redis-failover",
+					},
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							Name: "testing",
+						},
+					},
+				},
+				Spec: corev1.ServiceSpec{
+					Selector: map[string]string{
+						"app.kubernetes.io/component": "sentinel",
+						"app.kubernetes.io/name":      "custom-name",
+						"app.kubernetes.io/part-of":   "redis-failover",
+					},
+					Ports: []corev1.ServicePort{
+						{
+							Name:       "sentinel",
+							Port:       26379,
+							TargetPort: intstr.FromInt(26379),
+							Protocol:   "TCP",
+						},
+					},
+				},
+			},
+		},
+		{
+			name:        "with Namespace provided",
+			rfNamespace: "custom-namespace",
+			expectedService: corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      sentinelName,
+					Namespace: "custom-namespace",
+					Labels: map[string]string{
+						"app.kubernetes.io/component": "sentinel",
+						"app.kubernetes.io/name":      name,
+						"app.kubernetes.io/part-of":   "redis-failover",
+					},
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							Name: "testing",
+						},
+					},
+				},
+				Spec: corev1.ServiceSpec{
+					Selector: map[string]string{
+						"app.kubernetes.io/component": "sentinel",
+						"app.kubernetes.io/name":      name,
+						"app.kubernetes.io/part-of":   "redis-failover",
+					},
+					Ports: []corev1.ServicePort{
+						{
+							Name:       "sentinel",
+							Port:       26379,
+							TargetPort: intstr.FromInt(26379),
+							Protocol:   "TCP",
+						},
+					},
+				},
+			},
+		},
+		{
+			name:     "with Labels provided",
+			rfLabels: map[string]string{"some": "label"},
+			expectedService: corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      sentinelName,
+					Namespace: namespace,
+					Labels: map[string]string{
+						"app.kubernetes.io/component": "sentinel",
+						"app.kubernetes.io/name":      name,
+						"app.kubernetes.io/part-of":   "redis-failover",
+						"some":                        "label",
+					},
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							Name: "testing",
+						},
+					},
+				},
+				Spec: corev1.ServiceSpec{
+					Selector: map[string]string{
+						"app.kubernetes.io/component": "sentinel",
+						"app.kubernetes.io/name":      name,
+						"app.kubernetes.io/part-of":   "redis-failover",
+					},
+					Ports: []corev1.ServicePort{
+						{
+							Name:       "sentinel",
+							Port:       26379,
+							TargetPort: intstr.FromInt(26379),
+							Protocol:   "TCP",
+						},
+					},
+				},
+			},
+		},
+		{
+			name:          "with Annotations provided",
+			rfAnnotations: map[string]string{"some": "annotation"},
+			expectedService: corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      sentinelName,
+					Namespace: namespace,
+					Labels: map[string]string{
+						"app.kubernetes.io/component": "sentinel",
+						"app.kubernetes.io/name":      name,
+						"app.kubernetes.io/part-of":   "redis-failover",
+					},
+					Annotations: map[string]string{"some": "annotation"},
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							Name: "testing",
+						},
+					},
+				},
+				Spec: corev1.ServiceSpec{
+					Selector: map[string]string{
+						"app.kubernetes.io/component": "sentinel",
+						"app.kubernetes.io/name":      name,
+						"app.kubernetes.io/part-of":   "redis-failover",
+					},
+					Ports: []corev1.ServicePort{
+						{
+							Name:       "sentinel",
+							Port:       26379,
+							TargetPort: intstr.FromInt(26379),
+							Protocol:   "TCP",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert := assert.New(t)
+
+			// Generate a default RedisFailover and attaching the required annotations
+			rf := generateRF()
+			if test.rfName != "" {
+				rf.Name = test.rfName
+			}
+			if test.rfNamespace != "" {
+				rf.Namespace = test.rfNamespace
+			}
+			rf.Spec.Sentinel.ServiceAnnotations = test.rfAnnotations
+
+			generatedService := corev1.Service{}
+
+			ms := &mK8SService.Services{}
+			ms.On("CreateIfNotExistsService", rf.Namespace, mock.Anything).Once().Run(func(args mock.Arguments) {
+				s := args.Get(1).(*corev1.Service)
+				generatedService = *s
+			}).Return(nil)
+
+			client := rfservice.NewRedisFailoverKubeClient(ms, log.Dummy)
+			err := client.EnsureSentinelService(rf, test.rfLabels, []metav1.OwnerReference{{Name: "testing"}})
+
+			assert.Equal(test.expectedService, generatedService)
+			assert.NoError(err)
+		})
+	}
+}
+
+func TestRedisService(t *testing.T) {
+	tests := []struct {
+		name            string
+		rfName          string
+		rfNamespace     string
+		rfLabels        map[string]string
+		rfAnnotations   map[string]string
+		expectedService corev1.Service
+	}{
+		{
+			name: "with defaults",
+			expectedService: corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      redisName,
+					Namespace: namespace,
+					Labels: map[string]string{
+						"app.kubernetes.io/component": "redis",
+						"app.kubernetes.io/name":      name,
+						"app.kubernetes.io/part-of":   "redis-failover",
+					},
+					Annotations: map[string]string{
+						"prometheus.io/scrape": "true",
+						"prometheus.io/path":   "/metrics",
+						"prometheus.io/port":   "http",
+					},
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							Name: "testing",
+						},
+					},
+				},
+				Spec: corev1.ServiceSpec{
+					Type:      corev1.ServiceTypeClusterIP,
+					ClusterIP: corev1.ClusterIPNone,
+					Selector: map[string]string{
+						"app.kubernetes.io/component": "redis",
+						"app.kubernetes.io/name":      name,
+						"app.kubernetes.io/part-of":   "redis-failover",
+					},
+					Ports: []corev1.ServicePort{
+						{
+							Name:     "http-metrics",
+							Port:     9121,
+							Protocol: corev1.ProtocolTCP,
+						},
+					},
+				},
+			},
+		},
+		{
+			name:   "with Name provided",
+			rfName: "custom-name",
+			expectedService: corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "rfr-custom-name",
+					Namespace: namespace,
+					Labels: map[string]string{
+						"app.kubernetes.io/component": "redis",
+						"app.kubernetes.io/name":      "custom-name",
+						"app.kubernetes.io/part-of":   "redis-failover",
+					},
+					Annotations: map[string]string{
+						"prometheus.io/scrape": "true",
+						"prometheus.io/path":   "/metrics",
+						"prometheus.io/port":   "http",
+					},
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							Name: "testing",
+						},
+					},
+				},
+				Spec: corev1.ServiceSpec{
+					Type:      corev1.ServiceTypeClusterIP,
+					ClusterIP: corev1.ClusterIPNone,
+					Selector: map[string]string{
+						"app.kubernetes.io/component": "redis",
+						"app.kubernetes.io/name":      "custom-name",
+						"app.kubernetes.io/part-of":   "redis-failover",
+					},
+					Ports: []corev1.ServicePort{
+						{
+							Name:     "http-metrics",
+							Port:     9121,
+							Protocol: corev1.ProtocolTCP,
+						},
+					},
+				},
+			},
+		},
+		{
+			name:        "with Namespace provided",
+			rfNamespace: "custom-namespace",
+			expectedService: corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      redisName,
+					Namespace: "custom-namespace",
+					Labels: map[string]string{
+						"app.kubernetes.io/component": "redis",
+						"app.kubernetes.io/name":      name,
+						"app.kubernetes.io/part-of":   "redis-failover",
+					},
+					Annotations: map[string]string{
+						"prometheus.io/scrape": "true",
+						"prometheus.io/path":   "/metrics",
+						"prometheus.io/port":   "http",
+					},
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							Name: "testing",
+						},
+					},
+				},
+				Spec: corev1.ServiceSpec{
+					Type:      corev1.ServiceTypeClusterIP,
+					ClusterIP: corev1.ClusterIPNone,
+					Selector: map[string]string{
+						"app.kubernetes.io/component": "redis",
+						"app.kubernetes.io/name":      name,
+						"app.kubernetes.io/part-of":   "redis-failover",
+					},
+					Ports: []corev1.ServicePort{
+						{
+							Name:     "http-metrics",
+							Port:     9121,
+							Protocol: corev1.ProtocolTCP,
+						},
+					},
+				},
+			},
+		},
+		{
+			name:     "with Labels provided",
+			rfLabels: map[string]string{"some": "label"},
+			expectedService: corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      redisName,
+					Namespace: namespace,
+					Labels: map[string]string{
+						"app.kubernetes.io/component": "redis",
+						"app.kubernetes.io/name":      name,
+						"app.kubernetes.io/part-of":   "redis-failover",
+						"some":                        "label",
+					},
+					Annotations: map[string]string{
+						"prometheus.io/scrape": "true",
+						"prometheus.io/path":   "/metrics",
+						"prometheus.io/port":   "http",
+					},
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							Name: "testing",
+						},
+					},
+				},
+				Spec: corev1.ServiceSpec{
+					Type:      corev1.ServiceTypeClusterIP,
+					ClusterIP: corev1.ClusterIPNone,
+					Selector: map[string]string{
+						"app.kubernetes.io/component": "redis",
+						"app.kubernetes.io/name":      name,
+						"app.kubernetes.io/part-of":   "redis-failover",
+					},
+					Ports: []corev1.ServicePort{
+						{
+							Name:     "http-metrics",
+							Port:     9121,
+							Protocol: corev1.ProtocolTCP,
+						},
+					},
+				},
+			},
+		},
+		{
+			name:          "with Annotations provided",
+			rfAnnotations: map[string]string{"some": "annotation"},
+			expectedService: corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      redisName,
+					Namespace: namespace,
+					Labels: map[string]string{
+						"app.kubernetes.io/component": "redis",
+						"app.kubernetes.io/name":      name,
+						"app.kubernetes.io/part-of":   "redis-failover",
+					},
+					Annotations: map[string]string{
+						"prometheus.io/scrape": "true",
+						"prometheus.io/path":   "/metrics",
+						"prometheus.io/port":   "http",
+						"some":                 "annotation",
+					},
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							Name: "testing",
+						},
+					},
+				},
+				Spec: corev1.ServiceSpec{
+					Type:      corev1.ServiceTypeClusterIP,
+					ClusterIP: corev1.ClusterIPNone,
+					Selector: map[string]string{
+						"app.kubernetes.io/component": "redis",
+						"app.kubernetes.io/name":      name,
+						"app.kubernetes.io/part-of":   "redis-failover",
+					},
+					Ports: []corev1.ServicePort{
+						{
+							Name:     "http-metrics",
+							Port:     9121,
+							Protocol: corev1.ProtocolTCP,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert := assert.New(t)
+
+			// Generate a default RedisFailover and attaching the required annotations
+			rf := generateRF()
+			if test.rfName != "" {
+				rf.Name = test.rfName
+			}
+			if test.rfNamespace != "" {
+				rf.Namespace = test.rfNamespace
+			}
+			rf.Spec.Redis.ServiceAnnotations = test.rfAnnotations
+
+			generatedService := corev1.Service{}
+
+			ms := &mK8SService.Services{}
+			ms.On("CreateIfNotExistsService", rf.Namespace, mock.Anything).Once().Run(func(args mock.Arguments) {
+				s := args.Get(1).(*corev1.Service)
+				generatedService = *s
+			}).Return(nil)
+
+			client := rfservice.NewRedisFailoverKubeClient(ms, log.Dummy)
+			err := client.EnsureRedisService(rf, test.rfLabels, []metav1.OwnerReference{{Name: "testing"}})
+
+			assert.Equal(test.expectedService, generatedService)
+			assert.NoError(err)
+		})
 	}
 }
 


### PR DESCRIPTION
Fixes #219  .

For Reference: #170 
Changes proposed on the PR:
- adds in `serviceAnnotations` for both `Sentinel` and `Redis` configs
- backfills missing tests
