### PR TITLE
Use newer redis_exporter in examples

### DIFF
--- a/api/redisfailover/v1/defaults.go
+++ b/api/redisfailover/v1/defaults.go
@@ -4,7 +4,7 @@ const (
 	defaultRedisNumber    = 3
 	defaultSentinelNumber = 3
 	defaultSentinelExporterImage = "leominov/redis_sentinel_exporter:1.3.0"
-	defaultExporterImage  = "oliver006/redis_exporter:v0.33.0"
+	defaultExporterImage  = "oliver006/redis_exporter:v1.3.5-alpine"
 	defaultImage          = "redis:5.0-alpine"
 )
 

--- a/example/redisfailover/enable-exporter.yaml
+++ b/example/redisfailover/enable-exporter.yaml
@@ -12,4 +12,4 @@ spec:
     replicas: 3
     exporter: 
       enabled: true
-      image: oliver006/redis_exporter:v0.33.0
+      image: oliver006/redis_exporter:v1.3.5-alpine


### PR DESCRIPTION
redis_exporter in version lower than 1.0 contains bug oliver006/redis_exporter#300

Changes proposed on the PR:
- examples update
