### PR TITLE
Remove namespace from the ClusterRoleBinding.

### DIFF
--- a/example/operator/all-redis-operator-resources.yaml
+++ b/example/operator/all-redis-operator-resources.yaml
@@ -41,7 +41,6 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: redisoperator
-    namespace: default
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/example/operator/rolebinding.yaml
+++ b/example/operator/rolebinding.yaml
@@ -9,4 +9,3 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: redisoperator
-  namespace: default


### PR DESCRIPTION
Changes proposed on the PR:

No other Kubernetes object definitions specify a namespace, so for
the sake of consistency, remove the namespace from the ClusterRoleBinding.