### PR TITLE
Allow the Operator to run as non-root.

### DIFF
--- a/docker/app/Dockerfile
+++ b/docker/app/Dockerfile
@@ -8,5 +8,9 @@ FROM alpine:latest
 RUN apk --no-cache add \
   ca-certificates
 COPY --from=0 /go/src/github.com/spotahome/redis-operator/bin/linux/redis-operator /usr/local/bin
+RUN addgroup -g 1000 rf && \
+    adduser -D -u 1000 -G rf rf && \
+    chown rf:rf /usr/local/bin/redis-operator
+USER rf
 
 ENTRYPOINT ["/usr/local/bin/redis-operator"]

--- a/example/operator/all-redis-operator-resources.yaml
+++ b/example/operator/all-redis-operator-resources.yaml
@@ -21,6 +21,10 @@ spec:
         - image: quay.io/spotahome/redis-operator:latest
           imagePullPolicy: IfNotPresent
           name: app
+          securityContext:
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1000
           resources:
             limits:
               cpu: 100m

--- a/example/operator/operator.yaml
+++ b/example/operator/operator.yaml
@@ -21,6 +21,10 @@ spec:
         - image: quay.io/spotahome/redis-operator:latest
           imagePullPolicy: IfNotPresent
           name: app
+          securityContext:
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1000
           resources:
             limits:
               cpu: 100m


### PR DESCRIPTION
Fixes # 227

Changes proposed on the PR:

- Add a proper security context to the Redis Operator.

Without a proper security context, the Operator Pod fails to start up
with the following error in Kubernetes 1.13+:

```
Error: container has runAsNonRoot and image will run as root
```