### PR TITLE
Ensure pdb.minAvailable is always lower than choosen replicas

### DIFF
--- a/operator/redisfailover/service/client.go
+++ b/operator/redisfailover/service/client.go
@@ -130,6 +130,10 @@ func (r *RedisFailoverKubeClient) ensurePodDisruptionBudget(rf *redisfailoverv1.
 	namespace := rf.Namespace
 
 	minAvailable := intstr.FromInt(2)
+	if rf.Spec.Redis.Replicas <= 2 {
+		minAvailable = intstr.FromInt(int(rf.Spec.Redis.Replicas - 1))
+	}
+
 	labels = util.MergeLabels(labels, generateSelectorLabels(component, rf.Name))
 
 	pdb := generatePodDisruptionBudget(name, namespace, labels, ownerRefs, minAvailable)


### PR DESCRIPTION
The proposed change prevents running into problems updating Kubernetes clusters because of the pod disruption budget, if users deliberately decide to run less than 3 instances.