### PR TITLE
Add support for custom command renaming in Redis.

### DIFF
--- a/api/redisfailover/v1/types.go
+++ b/api/redisfailover/v1/types.go
@@ -23,26 +23,33 @@ type RedisFailoverSpec struct {
 	LabelWhitelist []string         `json:"labelWhitelist,omitempty"`
 }
 
+// RedisCommandRename defines the specification of a "rename-command" configuration option
+type RedisCommandRename struct {
+	From string `json:"from,omitempty"`
+	To   string `json:"to,omitempty"`
+}
+
 // RedisSettings defines the specification of the redis cluster
 type RedisSettings struct {
-	Image              string                        `json:"image,omitempty"`
-	ImagePullPolicy    corev1.PullPolicy             `json:"imagePullPolicy,omitempty"`
-	Replicas           int32                         `json:"replicas,omitempty"`
-	Resources          corev1.ResourceRequirements   `json:"resources,omitempty"`
-	CustomConfig       []string                      `json:"customConfig,omitempty"`
-	Command            []string                      `json:"command,omitempty"`
-	ShutdownConfigMap  string                        `json:"shutdownConfigMap,omitempty"`
-	Storage            RedisStorage                  `json:"storage,omitempty"`
-	Exporter           RedisExporter                 `json:"exporter,omitempty"`
-	Affinity           *corev1.Affinity              `json:"affinity,omitempty"`
-	SecurityContext    *corev1.PodSecurityContext    `json:"securityContext,omitempty"`
-	ImagePullSecrets   []corev1.LocalObjectReference `json:"imagePullSecrets,omitempty"`
-	Tolerations        []corev1.Toleration           `json:"tolerations,omitempty"`
-	NodeSelector       map[string]string             `json:"nodeSelector,omitempty"`
-	PodAnnotations     map[string]string             `json:"podAnnotations,omitempty"`
-	ServiceAnnotations map[string]string             `json:"serviceAnnotations,omitempty"`
-	HostNetwork        bool                          `json:"hostNetwork,omitempty"`
-	DNSPolicy          corev1.DNSPolicy              `json:"dnsPolicy,omitempty"`
+	Image                string                        `json:"image,omitempty"`
+	ImagePullPolicy      corev1.PullPolicy             `json:"imagePullPolicy,omitempty"`
+	Replicas             int32                         `json:"replicas,omitempty"`
+	Resources            corev1.ResourceRequirements   `json:"resources,omitempty"`
+	CustomConfig         []string                      `json:"customConfig,omitempty"`
+	CustomCommandRenames []RedisCommandRename          `json:"customCommandRenames,omitempty"`
+	Command              []string                      `json:"command,omitempty"`
+	ShutdownConfigMap    string                        `json:"shutdownConfigMap,omitempty"`
+	Storage              RedisStorage                  `json:"storage,omitempty"`
+	Exporter             RedisExporter                 `json:"exporter,omitempty"`
+	Affinity             *corev1.Affinity              `json:"affinity,omitempty"`
+	SecurityContext      *corev1.PodSecurityContext    `json:"securityContext,omitempty"`
+	ImagePullSecrets     []corev1.LocalObjectReference `json:"imagePullSecrets,omitempty"`
+	Tolerations          []corev1.Toleration           `json:"tolerations,omitempty"`
+	NodeSelector         map[string]string             `json:"nodeSelector,omitempty"`
+	PodAnnotations       map[string]string             `json:"podAnnotations,omitempty"`
+	ServiceAnnotations   map[string]string             `json:"serviceAnnotations,omitempty"`
+	HostNetwork          bool                          `json:"hostNetwork,omitempty"`
+	DNSPolicy            corev1.DNSPolicy              `json:"dnsPolicy,omitempty"`
 }
 
 // SentinelSettings defines the specification of the sentinel cluster

--- a/example/redisfailover/custom-renames.yaml
+++ b/example/redisfailover/custom-renames.yaml
@@ -1,0 +1,16 @@
+apiVersion: databases.spotahome.com/v1
+kind: RedisFailover
+metadata:
+  name: redisfailover
+spec:
+  sentinel:
+    replicas: 3
+  redis:
+    replicas: 3
+    customCommandRenames:
+      - from: "monitor"
+        to: ""
+      - from: "flushall"
+        to: "fa"
+      - from: flushdb
+        to: xxfd

--- a/operator/redisfailover/service/client.go
+++ b/operator/redisfailover/service/client.go
@@ -76,7 +76,7 @@ func (r *RedisFailoverKubeClient) EnsureRedisStatefulset(rf *redisfailoverv1.Red
 	return r.K8SService.CreateOrUpdateStatefulSet(rf.Namespace, ss)
 }
 
-// EnsureRedisConfigMap makes sure the sentinel configmap exists
+// EnsureRedisConfigMap makes sure the Redis ConfigMap exists
 func (r *RedisFailoverKubeClient) EnsureRedisConfigMap(rf *redisfailoverv1.RedisFailover, labels map[string]string, ownerRefs []metav1.OwnerReference) error {
 
 	password, err := k8s.GetRedisPassword(r.K8SService, rf)

--- a/operator/redisfailover/service/generator.go
+++ b/operator/redisfailover/service/generator.go
@@ -25,7 +25,7 @@ tcp-keepalive 60
 save 900 1
 save 300 10
 {{- range .Spec.Redis.CustomCommandRenames}}
-rename-command {{.From}} {{.To}}
+rename-command "{{.From}}" "{{.To}}"
 {{- end}}
 `
 	redisShutdownConfigurationVolumeName = "redis-shutdown-config"


### PR DESCRIPTION
The ability to rename commands in Redis is a way to improve
security by obscuring certain operations or by disabling them
entirely.

Fixes #233

Changes proposed on the PR:
- A new section in the Redis `spec` that is named `CustomCommandRenames`
- `CustomCommandRenames` is an array of tuples
- Each tuple is in the form `(from, to)`
- Each tuple will generate a line in the `redis.conf` file that reads `rename-command ${from} {to}`