### PR TITLE
Service monitor in option

### DIFF
--- a/charts/redisoperator/Chart.yaml
+++ b/charts/redisoperator/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for the Spotahome Redis Operator
 name: redisoperator
-version: 3.0.0
+version: 3.1.0

--- a/charts/redisoperator/templates/monitoring.yaml
+++ b/charts/redisoperator/templates/monitoring.yaml
@@ -6,6 +6,7 @@ metadata:
   labels:
     prometheus: {{ .Values.monitoring.prometheus.name }}
 {{ include "helm-labels" . | indent 4 }}
+{{ include .Values.monitoring.labes . | indent 4 }}
 spec:
   ports:
     - port: 9710
@@ -16,6 +17,7 @@ spec:
 {{ include "common-labels" . | indent 4 }}
 
 ---
+{{- if .Values.monitoring.serviceMonitor -}}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
@@ -34,4 +36,5 @@ spec:
   endpoints:
   - port: metrics
     interval: 15s
+{{- end -}}
 {{- end -}}

--- a/charts/redisoperator/templates/monitoring.yaml
+++ b/charts/redisoperator/templates/monitoring.yaml
@@ -6,7 +6,9 @@ metadata:
   labels:
     prometheus: {{ .Values.monitoring.prometheus.name }}
 {{ include "helm-labels" . | indent 4 }}
-{{ include .Values.monitoring.labels . | indent 4 }}
+{{- if .Values.monitoring.labels -}}
+{{ toYaml .Values.monitoring.labels | indent 4 }}
+{{ end }}
 spec:
   ports:
     - port: 9710

--- a/charts/redisoperator/templates/monitoring.yaml
+++ b/charts/redisoperator/templates/monitoring.yaml
@@ -6,9 +6,10 @@ metadata:
   labels:
     prometheus: {{ .Values.monitoring.prometheus.name }}
 {{ include "helm-labels" . | indent 4 }}
-{{- if .Values.monitoring.labels -}}
-{{ toYaml .Values.monitoring.labels | indent 4 }}
-{{ end }}
+{{- if .Values.serviceAnnotations }}
+  annotations:
+{{ toYaml .Values.serviceAnnotations | indent 4 }}
+{{- end }}
 spec:
   ports:
     - port: 9710

--- a/charts/redisoperator/templates/monitoring.yaml
+++ b/charts/redisoperator/templates/monitoring.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     prometheus: {{ .Values.monitoring.prometheus.name }}
 {{ include "helm-labels" . | indent 4 }}
-{{ include .Values.monitoring.labes . | indent 4 }}
+{{ include .Values.monitoring.labels . | indent 4 }}
 spec:
   ports:
     - port: 9710
@@ -18,7 +18,7 @@ spec:
 
 ---
 {{- if .Values.monitoring.serviceMonitor -}}
-apiVersion: monitoring.coreos.com/v1
+apiVersion: monitoring.coreos.com/v1 
 kind: ServiceMonitor
 metadata:
   name: {{ template "name" . }}

--- a/charts/redisoperator/templates/monitoring.yaml
+++ b/charts/redisoperator/templates/monitoring.yaml
@@ -6,9 +6,9 @@ metadata:
   labels:
     prometheus: {{ .Values.monitoring.prometheus.name }}
 {{ include "helm-labels" . | indent 4 }}
-{{- if .Values.serviceAnnotations }}
+{{- if .Values.monitoring.serviceAnnotations }}
   annotations:
-{{ toYaml .Values.serviceAnnotations | indent 4 }}
+{{ toYaml .Values.monitoring.serviceAnnotations | indent 4 }}
 {{- end }}
 spec:
   ports:

--- a/charts/redisoperator/values.yaml
+++ b/charts/redisoperator/values.yaml
@@ -3,6 +3,7 @@ tag: latest
 pullPolicy: Always
 containerName: redisoperator
 podAnnotations: {}
+serviceAnnotations: {}
 resources:
   requests:
     cpu: 10m
@@ -17,6 +18,6 @@ rbac:
 monitoring:
   enabled: false
   serviceMonitor: false
-  labels: {}
+
   prometheus:
     name: unknown

--- a/charts/redisoperator/values.yaml
+++ b/charts/redisoperator/values.yaml
@@ -3,7 +3,6 @@ tag: latest
 pullPolicy: Always
 containerName: redisoperator
 podAnnotations: {}
-serviceAnnotations: {}
 resources:
   requests:
     cpu: 10m
@@ -18,6 +17,6 @@ rbac:
 monitoring:
   enabled: false
   serviceMonitor: false
-
+  serviceAnnotations: {}
   prometheus:
     name: unknown

--- a/charts/redisoperator/values.yaml
+++ b/charts/redisoperator/values.yaml
@@ -16,5 +16,7 @@ rbac:
   imagePullSecrets: []
 monitoring:
   enabled: false
+  serviceMonitor: false
+  labels: {}
   prometheus:
     name: unknown


### PR DESCRIPTION
For everybody who don't have prometheus operator we cannot deploy service monitor. 

Changes proposed on the PR:
- Add option to deploy Service monitor
- Add annotations for service (to be able to add prometheus scraping config)
