### PR TITLE
Add env and args customization for exporters

### DIFF
--- a/api/redisfailover/v1/types.go
+++ b/api/redisfailover/v1/types.go
@@ -90,6 +90,8 @@ type RedisExporter struct {
 	Enabled         bool              `json:"enabled,omitempty"`
 	Image           string            `json:"image,omitempty"`
 	ImagePullPolicy corev1.PullPolicy `json:"imagePullPolicy,omitempty"`
+	Args            []string          `json:"args,omitempty"`
+	Env             []corev1.EnvVar   `json:"env,omitempty"`
 }
 
 // SentinelExporter defines the specification for the sentinel exporter
@@ -97,6 +99,8 @@ type SentinelExporter struct {
 	Enabled         bool              `json:"enabled,omitempty"`
 	Image           string            `json:"image,omitempty"`
 	ImagePullPolicy corev1.PullPolicy `json:"imagePullPolicy,omitempty"`
+	Args            []string          `json:"args,omitempty"`
+	Env             []corev1.EnvVar   `json:"env,omitempty"`
 }
 
 // RedisStorage defines the structure used to store the Redis Data

--- a/example/redisfailover/enable-exporter.yaml
+++ b/example/redisfailover/enable-exporter.yaml
@@ -13,3 +13,9 @@ spec:
     exporter: 
       enabled: true
       image: oliver006/redis_exporter:v1.3.5-alpine
+      args:
+        - --web.telemetry-path
+        - /metrics
+      env:
+        - name: REDIS_EXPORTER_LOG_FORMAT
+          value: txt

--- a/operator/redisfailover/service/generator.go
+++ b/operator/redisfailover/service/generator.go
@@ -533,8 +533,8 @@ func createRedisExporterContainer(rf *redisfailoverv1.RedisFailover) corev1.Cont
 		Name:            exporterContainerName,
 		Image:           rf.Spec.Redis.Exporter.Image,
 		ImagePullPolicy: pullPolicy(rf.Spec.Redis.Exporter.ImagePullPolicy),
-		Env: []corev1.EnvVar{
-			{
+		Args:            rf.Spec.Redis.Exporter.Args,
+		Env:             append(rf.Spec.Redis.Exporter.Env, corev1.EnvVar{
 				Name: "REDIS_ALIAS",
 				ValueFrom: &corev1.EnvVarSource{
 					FieldRef: &corev1.ObjectFieldSelector{
@@ -542,7 +542,7 @@ func createRedisExporterContainer(rf *redisfailoverv1.RedisFailover) corev1.Cont
 					},
 				},
 			},
-		},
+		),
 		Ports: []corev1.ContainerPort{
 			{
 				Name:          "metrics",
@@ -585,6 +585,8 @@ func createSentinelExporterContainer(rf *redisfailoverv1.RedisFailover) corev1.C
 		Name:            sentinelExporterContainerName,
 		Image:           rf.Spec.Sentinel.Exporter.Image,
 		ImagePullPolicy: pullPolicy(rf.Spec.Sentinel.Exporter.ImagePullPolicy),
+		Args:            rf.Spec.Sentinel.Exporter.Args,
+		Env:             rf.Spec.Sentinel.Exporter.Env,
 		Ports: []corev1.ContainerPort{
 			{
 				Name:          "metrics",


### PR DESCRIPTION
Exporters have many useful configuration options/environment variables, e. g. `oliver006/redis_exporter` has a few dozen options that can't be configured from RedisFailover CRD.

Changes proposed on the PR:
Add `env` and `args` optional parameters to the `spec.sentinel.exporter` and `spec.redis.exporter` in RedisFailover CRD.