### PR TITLE
Fixed a bug due to which sentinel from not ready nodes get into the sentinels array

### DIFF
--- a/operator/redisfailover/service/check.go
+++ b/operator/redisfailover/service/check.go
@@ -199,7 +199,7 @@ func (r *RedisFailoverChecker) GetRedisesIPs(rf *redisfailoverv1.RedisFailover) 
 		return nil, err
 	}
 	for _, rp := range rps.Items {
-		if rp.Status.Phase == corev1.PodRunning { // Only work with running pods
+		if rp.Status.Phase == corev1.PodRunning && rp.DeletionTimestamp == nil { // Only work with running pods
 			redises = append(redises, rp.Status.PodIP)
 		}
 	}
@@ -214,7 +214,7 @@ func (r *RedisFailoverChecker) GetSentinelsIPs(rf *redisfailoverv1.RedisFailover
 		return nil, err
 	}
 	for _, sp := range rps.Items {
-		if sp.Status.Phase == corev1.PodRunning { // Only work with running pods
+		if sp.Status.Phase == corev1.PodRunning && sp.DeletionTimestamp == nil { // Only work with running pods
 			sentinels = append(sentinels, sp.Status.PodIP)
 		}
 	}
@@ -256,7 +256,7 @@ func (r *RedisFailoverChecker) GetRedisesSlavesPods(rf *redisfailoverv1.RedisFai
 	}
 
 	for _, rp := range rps.Items {
-		if rp.Status.Phase == corev1.PodRunning { // Only work with running
+		if rp.Status.Phase == corev1.PodRunning && rp.DeletionTimestamp == nil { // Only work with running
 			master, err := r.redisClient.IsMaster(rp.Status.PodIP, password)
 			if err != nil {
 				return []string{}, err
@@ -282,7 +282,7 @@ func (r *RedisFailoverChecker) GetRedisesMasterPod(rFailover *redisfailoverv1.Re
 	}
 
 	for _, rp := range rps.Items {
-		if rp.Status.Phase == corev1.PodRunning { // Only work with running
+		if rp.Status.Phase == corev1.PodRunning && rp.DeletionTimestamp == nil { // Only work with running
 			master, err := r.redisClient.IsMaster(rp.Status.PodIP, password)
 			if err != nil {
 				return "", err


### PR DESCRIPTION
I found the problem that if one of the worker nodes crashes, where the sentinel pods were located. Then the operator cannot appoint a master, even when all sentinel pods have started on other worker nodes.

Example:

manifest:
```
apiVersion: databases.spotahome.com/v1
kind: RedisFailover
metadata:
  name: redis
spec:
  sentinel:
    replicas: 3
    securityContext: {}
    resources:
      requests:
        cpu: 100m
        memory: 50Mi
      limits:
        cpu: 300m
        memory: 100Mi
  redis:
    replicas: 2
    securityContext: {}
    resources:
      requests:
        cpu: 100m
        memory: 100Mi
      limits:
        cpu: 400m
        memory: 500Mi
```

`kubectl get nodes`:
```
NAME               STATUS     ROLES    AGE     VERSION
kube-master999-1   Ready      master   163m    v1.18.8
kube-worker999-1   Ready      <none>   162m    v1.18.8
kube-worker999-2   Ready      <none>   162m    v1.18.8
kube-worker999-3   NotReady   <none>   162m    v1.18.8
kube-worker999-4   NotReady   <none>   8m35s   v1.18.8
```

` kubectl get po -o wide`:
```
#
NAME                         READY   STATUS        RESTARTS   AGE    IP            NODE               NOMINATED NODE   READINESS GATES
redis-mon-58d96bc847-8qb97   1/1     Running       15         65m    10.244.2.6    kube-worker999-1   <none>           <none>
rfr-redis-0                  1/1     Running       0          93m    10.244.3.2    kube-worker999-2   <none>           <none>
rfr-redis-1                  1/1     Running       0          93m    10.244.2.2    kube-worker999-1   <none>           <none>
rfs-redis-856c46c8d4-5b99m   1/1     Running       0          9m1s   10.244.3.9    kube-worker999-2   <none>           <none>
rfs-redis-856c46c8d4-69vwc   1/1     Terminating   0          93m    10.244.1.3    kube-worker999-3   <none>           <none>
rfs-redis-856c46c8d4-fs62p   1/1     Running       0          90s    10.244.3.10   kube-worker999-2   <none>           <none>
rfs-redis-856c46c8d4-jg8ds   1/1     Terminating   0          9m1s   10.244.4.2    kube-worker999-4   <none>           <none>
rfs-redis-856c46c8d4-v8z9k   1/1     Running       0          9m1s   10.244.2.8    kube-worker999-1   <none>           <none>
```
pod `rfs-redis-856c46c8d4-69vwc` (`10.244.1.3`, notReady node `kube-worker999-3`)  and pod `rfs-redis-856c46c8d4-jg8ds` (`10.244.4.2`, notReady node `kube-worker999-4`) are "terminating" status. 

But their field "status.Phage" is equal to "Running":
<details>
  <summary>kubectl get po rfs-redis-856c46c8d4-69vwc -o yaml:</summary>

```yaml
apiVersion: v1
kind: Pod
metadata:
  annotations:
    kubernetes.io/psp: default
  creationTimestamp: "2020-08-25T09:18:54Z"
  deletionGracePeriodSeconds: 30
  deletionTimestamp: "2020-08-25T09:35:09Z"
  generateName: rfs-redis-856c46c8d4-
  labels:
    app.kubernetes.io/component: sentinel
    app.kubernetes.io/managed-by: redis-operator
    app.kubernetes.io/name: redis
    app.kubernetes.io/part-of: redis-failover
    pod-template-hash: 856c46c8d4
    redisfailovers.databases.spotahome.com/name: redis
  managedFields:
  - apiVersion: v1
    fieldsType: FieldsV1
    fieldsV1:
      f:status:
        f:conditions:
          k:{"type":"ContainersReady"}:
            .: {}
            f:lastProbeTime: {}
            f:lastTransitionTime: {}
            f:status: {}
            f:type: {}
          k:{"type":"Initialized"}:
            .: {}
            f:lastProbeTime: {}
            f:lastTransitionTime: {}
            f:status: {}
            f:type: {}
          k:{"type":"Ready"}:
            .: {}
            f:lastProbeTime: {}
            f:type: {}
        f:containerStatuses: {}
        f:hostIP: {}
        f:initContainerStatuses: {}
        f:phase: {}
        f:podIP: {}
        f:podIPs:
          .: {}
          k:{"ip":"10.244.1.3"}:
            .: {}
            f:ip: {}
        f:startTime: {}
    manager: kubelet
    operation: Update
    time: "2020-08-25T09:19:44Z"
  - apiVersion: v1
    fieldsType: FieldsV1
    fieldsV1:
      f:metadata:
        f:generateName: {}
        f:labels:
          .: {}
          f:app.kubernetes.io/component: {}
          f:app.kubernetes.io/managed-by: {}
          f:app.kubernetes.io/name: {}
          f:app.kubernetes.io/part-of: {}
          f:pod-template-hash: {}
          f:redisfailovers.databases.spotahome.com/name: {}
        f:ownerReferences:
          .: {}
          k:{"uid":"7270aab6-4381-465d-a2dc-8fe9e36ffc79"}:
            .: {}
            f:apiVersion: {}
            f:blockOwnerDeletion: {}
            f:controller: {}
            f:kind: {}
            f:name: {}
            f:uid: {}
      f:spec:
        f:affinity:
          .: {}
          f:podAntiAffinity:
            .: {}
            f:preferredDuringSchedulingIgnoredDuringExecution: {}
        f:containers:
          k:{"name":"sentinel"}:
            .: {}
            f:command: {}
            f:image: {}
            f:imagePullPolicy: {}
            f:livenessProbe:
              .: {}
              f:exec:
                .: {}
                f:command: {}
              f:failureThreshold: {}
              f:initialDelaySeconds: {}
              f:periodSeconds: {}
              f:successThreshold: {}
              f:timeoutSeconds: {}
            f:name: {}
            f:ports:
              .: {}
              k:{"containerPort":26379,"protocol":"TCP"}:
                .: {}
                f:containerPort: {}
                f:name: {}
                f:protocol: {}
            f:readinessProbe:
              .: {}
              f:exec:
                .: {}
                f:command: {}
              f:failureThreshold: {}
              f:initialDelaySeconds: {}
              f:periodSeconds: {}
              f:successThreshold: {}
              f:timeoutSeconds: {}
            f:resources:
              .: {}
              f:limits:
                .: {}
                f:cpu: {}
                f:memory: {}
              f:requests:
                .: {}
                f:cpu: {}
                f:memory: {}
            f:terminationMessagePath: {}
            f:terminationMessagePolicy: {}
            f:volumeMounts:
              .: {}
              k:{"mountPath":"/redis"}:
                .: {}
                f:mountPath: {}
                f:name: {}
        f:dnsPolicy: {}
        f:enableServiceLinks: {}
        f:initContainers:
          .: {}
          k:{"name":"sentinel-config-copy"}:
            .: {}
            f:command: {}
            f:image: {}
            f:imagePullPolicy: {}
            f:name: {}
            f:resources:
              .: {}
              f:limits:
                .: {}
                f:cpu: {}
                f:memory: {}
              f:requests:
                .: {}
                f:cpu: {}
                f:memory: {}
            f:terminationMessagePath: {}
            f:terminationMessagePolicy: {}
            f:volumeMounts:
              .: {}
              k:{"mountPath":"/redis"}:
                .: {}
                f:mountPath: {}
                f:name: {}
              k:{"mountPath":"/redis-writable"}:
                .: {}
                f:mountPath: {}
                f:name: {}
        f:restartPolicy: {}
        f:schedulerName: {}
        f:securityContext: {}
        f:terminationGracePeriodSeconds: {}
        f:volumes:
          .: {}
          k:{"name":"sentinel-config"}:
            .: {}
            f:configMap:
              .: {}
              f:defaultMode: {}
              f:name: {}
            f:name: {}
          k:{"name":"sentinel-config-writable"}:
            .: {}
            f:emptyDir: {}
            f:name: {}
      f:status:
        f:conditions:
          k:{"type":"Ready"}:
            f:lastTransitionTime: {}
            f:status: {}
    manager: kube-controller-manager
    operation: Update
    time: "2020-08-25T09:29:34Z"
  name: rfs-redis-856c46c8d4-69vwc
  namespace: default
  ownerReferences:
  - apiVersion: apps/v1
    blockOwnerDeletion: true
    controller: true
    kind: ReplicaSet
    name: rfs-redis-856c46c8d4
    uid: 7270aab6-4381-465d-a2dc-8fe9e36ffc79
  resourceVersion: "14033"
  selfLink: /api/v1/namespaces/default/pods/rfs-redis-856c46c8d4-69vwc
  uid: 5495a3dc-1faf-4528-86da-bdc0fa81f8c0
spec:
  affinity:
    podAntiAffinity:
      preferredDuringSchedulingIgnoredDuringExecution:
      - podAffinityTerm:
          labelSelector:
            matchLabels:
              app.kubernetes.io/component: sentinel
              app.kubernetes.io/managed-by: redis-operator
              app.kubernetes.io/name: redis
              app.kubernetes.io/part-of: redis-failover
              redisfailovers.databases.spotahome.com/name: redis
          topologyKey: kubernetes.io/hostname
        weight: 100
  containers:
  - command:
    - redis-server
    - /redis/sentinel.conf
    - --sentinel
    image: redis:5.0-alpine
    imagePullPolicy: Always
    livenessProbe:
      exec:
        command:
        - sh
        - -c
        - redis-cli -h $(hostname) -p 26379 ping
      failureThreshold: 3
      initialDelaySeconds: 30
      periodSeconds: 10
      successThreshold: 1
      timeoutSeconds: 5
    name: sentinel
    ports:
    - containerPort: 26379
      name: sentinel
      protocol: TCP
    readinessProbe:
      exec:
        command:
        - sh
        - -c
        - redis-cli -h $(hostname) -p 26379 ping
      failureThreshold: 3
      initialDelaySeconds: 30
      periodSeconds: 10
      successThreshold: 1
      timeoutSeconds: 5
    resources:
      limits:
        cpu: 300m
        memory: 100Mi
      requests:
        cpu: 100m
        memory: 50Mi
    securityContext:
      allowPrivilegeEscalation: false
      readOnlyRootFilesystem: true
      runAsGroup: 4601
      runAsUser: 4601
    terminationMessagePath: /dev/termination-log
    terminationMessagePolicy: File
    volumeMounts:
    - mountPath: /redis
      name: sentinel-config-writable
    - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
      name: default-token-zlnb4
      readOnly: true
  dnsPolicy: ClusterFirst
  enableServiceLinks: true
  initContainers:
  - command:
    - cp
    - /redis/sentinel.conf
    - /redis-writable/sentinel.conf
    image: redis:5.0-alpine
    imagePullPolicy: Always
    name: sentinel-config-copy
    resources:
      limits:
        cpu: 10m
        memory: 32Mi
      requests:
        cpu: 10m
        memory: 32Mi
    securityContext:
      allowPrivilegeEscalation: false
      readOnlyRootFilesystem: true
      runAsGroup: 4601
      runAsUser: 4601
    terminationMessagePath: /dev/termination-log
    terminationMessagePolicy: File
    volumeMounts:
    - mountPath: /redis
      name: sentinel-config
    - mountPath: /redis-writable
      name: sentinel-config-writable
    - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
      name: default-token-zlnb4
      readOnly: true
  nodeName: kube-worker999-3
  priority: 100
  priorityClassName: default
  restartPolicy: Always
  schedulerName: default-scheduler
  securityContext:
    fsGroup: 4601
    supplementalGroups:
    - 4601
  serviceAccount: default
  serviceAccountName: default
  terminationGracePeriodSeconds: 30
  tolerations:
  - effect: NoExecute
    key: node.kubernetes.io/not-ready
    operator: Exists
    tolerationSeconds: 300
  - effect: NoExecute
    key: node.kubernetes.io/unreachable
    operator: Exists
    tolerationSeconds: 300
  volumes:
  - configMap:
      defaultMode: 420
      name: rfs-redis
    name: sentinel-config
  - emptyDir: {}
    name: sentinel-config-writable
  - name: default-token-zlnb4
    secret:
      defaultMode: 420
      secretName: default-token-zlnb4
status:
  conditions:
  - lastProbeTime: null
    lastTransitionTime: "2020-08-25T09:19:04Z"
    status: "True"
    type: Initialized
  - lastProbeTime: null
    lastTransitionTime: "2020-08-25T09:29:34Z"
    status: "False"
    type: Ready
  - lastProbeTime: null
    lastTransitionTime: "2020-08-25T09:19:44Z"
    status: "True"
    type: ContainersReady
  - lastProbeTime: null
    lastTransitionTime: "2020-08-25T09:18:54Z"
    status: "True"
    type: PodScheduled
  containerStatuses:
  - containerID: docker://7605c983b944901856598f2b24222c02fde742d005212afb22d68eb98f9b856f
    image: redis:5.0-alpine
    imageID: docker-pullable://redis@sha256:b011c1ca7fa97ed92d6c5995e5dd752dc37fe157c1b60ce96a6e35701851dabc
    lastState: {}
    name: sentinel
    ready: true
    restartCount: 0
    started: true
    state:
      running:
        startedAt: "2020-08-25T09:19:06Z"
  hostIP: 192.168.1.10
  initContainerStatuses:
  - containerID: docker://0d8ee678fda9348502d41c6f61543f51eb005fae38a230f81fb683d3da595d9e
    image: redis:5.0-alpine
    imageID: docker-pullable://redis@sha256:b011c1ca7fa97ed92d6c5995e5dd752dc37fe157c1b60ce96a6e35701851dabc
    lastState: {}
    name: sentinel-config-copy
    ready: true
    restartCount: 0
    state:
      terminated:
        containerID: docker://0d8ee678fda9348502d41c6f61543f51eb005fae38a230f81fb683d3da595d9e
        exitCode: 0
        finishedAt: "2020-08-25T09:19:03Z"
        reason: Completed
        startedAt: "2020-08-25T09:19:03Z"
  phase: Running
  podIP: 10.244.1.3
  podIPs:
  - ip: 10.244.1.3
  qosClass: Burstable
  startTime: "2020-08-25T09:18:54Z"
```
</details>

2 sentinel in "Terminating" status have been replaced with new ones (`rfs-redis-856c46c8d4-5b99m` - `10.244.3.9`, `rfs-redis-856c46c8d4-fs62p` - `10.244.3.10`). But If you go to the sentinel, then 127.0.0.1 will be indicated as a master there:
```bash
/data $ redis-cli -h rfs-redis -p 26379
rfs-redis:26379> sentinel masters
1)  1) "name"
    2) "mymaster"
    3) "ip"
    4) "127.0.0.1"
    5) "port"
    6) "6379"
    7) "runid"
    8) ""
    9) "flags"
   10) "s_down,master,disconnected"
   11) "link-pending-commands"
   12) "3"
   13) "link-refcount"
   14) "1"
   15) "last-ping-sent"
   16) "633247"
   17) "last-ok-ping-reply"
   18) "633247"
   19) "last-ping-reply"
   20) "633247"
   21) "s-down-time"
   22) "632173"
   23) "down-after-milliseconds"
   24) "1000"
   25) "info-refresh"
   26) "1598352823337"
   27) "role-reported"
   28) "master"
   29) "role-reported-time"
   30) "633247"
   31) "config-epoch"
```

Because of this, the application will not be able to connect to the redis:
```
redis: 2020/08/25 10:54:35 sentinel.go:435: sentinel: new master="mymaster" addr="127.0.0.1:6379"
[2020-08-25T10:54:35Z] Error connect redis (1/10): dial tcp 127.0.0.1:6379: connect: connection refused
[2020-08-25T10:54:38Z] Error connect redis (2/10): dial tcp 127.0.0.1:6379: connect: connection refused
```

In operator logs errors:
```
time="2020-08-25T10:55:36Z" level=error msg="Error processing default/redis: dial tcp 10.244.1.3:26379: i/o timeout" controller=redisfailover operator=redis-operator src="generic.go:224"
```

If you display an array of sentries at this moment, it will look like this:
```
Sentinels: [10.244.3.9 10.244.1.3 10.244.3.10 10.244.4.2 10.244.2.8]
```
10.244.4.2 and 10.244.1.3 are "terminating" status in kubectl.

I added an additional check on the Pod.DeletionTimestamp field, just like it was done in kubectl (https://github.com/kubernetes/kubernetes/blob/7ceac2baf0820fd354259aa8b7f0e37b0bc6b814/staging/src/k8s.io/kubectl/pkg/describe/describe.go#L722)

```golang
                if sp.Status.Phase == corev1.PodRunning && sp.DeletionTimestamp == nil { // Only work with running pods
                        sentinels = append(sentinels, sp.Status.PodIP)
                }
```
And this solves the problem, at least at the moment when the sentinel pods will be marked for deletion(`Pod.DeletionTimestamp`) on the not ready nodes.

