### PR TITLE
Added support for the "prirotyClassName" field

### DIFF
--- a/api/redisfailover/v1/types.go
+++ b/api/redisfailover/v1/types.go
@@ -51,6 +51,7 @@ type RedisSettings struct {
 	ServiceAnnotations   map[string]string             `json:"serviceAnnotations,omitempty"`
 	HostNetwork          bool                          `json:"hostNetwork,omitempty"`
 	DNSPolicy            corev1.DNSPolicy              `json:"dnsPolicy,omitempty"`
+	PriorityClassName    string                        `json:"priorityClassName,omitempty"`
 }
 
 // SentinelSettings defines the specification of the sentinel cluster
@@ -71,6 +72,7 @@ type SentinelSettings struct {
 	Exporter           SentinelExporter              `json:"exporter,omitempty"`
 	HostNetwork        bool                          `json:"hostNetwork,omitempty"`
 	DNSPolicy          corev1.DNSPolicy              `json:"dnsPolicy,omitempty"`
+	PriorityClassName  string                        `json:"priorityClassName,omitempty"`
 }
 
 // AuthSettings contains settings about auth

--- a/operator/redisfailover/service/generator.go
+++ b/operator/redisfailover/service/generator.go
@@ -273,6 +273,7 @@ func generateRedisStatefulSet(rf *redisfailoverv1.RedisFailover, labels map[stri
 					HostNetwork:      rf.Spec.Redis.HostNetwork,
 					DNSPolicy:        getDnsPolicy(rf.Spec.Redis.DNSPolicy),
 					ImagePullSecrets: rf.Spec.Redis.ImagePullSecrets,
+					PriorityClassName: rf.Spec.Redis.PriorityClassName,
 					Containers: []corev1.Container{
 						{
 							Name:            "redis",
@@ -391,6 +392,7 @@ func generateSentinelDeployment(rf *redisfailoverv1.RedisFailover, labels map[st
 					HostNetwork:      rf.Spec.Sentinel.HostNetwork,
 					DNSPolicy:        getDnsPolicy(rf.Spec.Sentinel.DNSPolicy),
 					ImagePullSecrets: rf.Spec.Sentinel.ImagePullSecrets,
+					PriorityClassName: rf.Spec.Sentinel.PriorityClassName,
 					InitContainers: []corev1.Container{
 						{
 							Name:            "sentinel-config-copy",


### PR DESCRIPTION
Added support for the "prirotyClassName" field for sentinel and redis pods

For example:
```yaml
apiVersion: scheduling.k8s.io/v1
kind: PriorityClass
metadata:
  name: prod
value: 150
globalDefault: false
description: "prod"
---
apiVersion: scheduling.k8s.io/v1
kind: PriorityClass
metadata:
  name: prod
value: 500
globalDefault: false
description: "prod-databases"
---
apiVersion: databases.spotahome.com/v1
kind: RedisFailover
metadata:
  name: redis
  namespace: default
spec:
  sentinel:
    replicas: 3
    securityContext: {}
    priorityClassName: "prod"
    resources:
      requests:
        cpu: 100m
        memory: 50Mi
      limits:
        cpu: 300m
        memory: 100Mi
  redis:
    replicas: 2
    securityContext: {}
    priorityClassName: "prod-databases"
    resources:
      requests:
        cpu: 100m
        memory: 100Mi
      limits:
        cpu: 400m
        memory: 500Mi
```