### PR TITLE
Update golang to 1.13

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ env:
 
 language: go
 go:
-  - "1.12.x"
+  - "1.13.x"
 go_import_path: github.com/spotahome/redis-operator
 
 before_script:

--- a/docker/app/Dockerfile
+++ b/docker/app/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.12-alpine
+FROM golang:1.13-alpine
 
 WORKDIR /go/src/github.com/spotahome/redis-operator
 COPY . .

--- a/docker/development/Dockerfile
+++ b/docker/development/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.12-alpine
+FROM golang:1.13-alpine
 
 ENV CODEGEN_VERSION="1.11.9"
 


### PR DESCRIPTION
Changes proposed on the PR:

- Update golang to 1.13 to resolve build issues (stretchr/testify#991).

Not sure if it's worth advancing to later versions or just keep to the lowest required to build?