### PR TITLE
Publish Helm chart via GitHub Releases and Pages

### DIFF
--- a/.github/workflows/helm.yml
+++ b/.github/workflows/helm.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
     - master
+    - publish
 
 jobs:
   release:

--- a/.github/workflows/helm.yml
+++ b/.github/workflows/helm.yml
@@ -1,0 +1,22 @@
+name: Helm
+
+on:
+  push:
+    branches:
+    - master
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+    - name: Configure Git
+      run: |
+        git config user.name "$GITHUB_ACTOR"
+        git config user.email "${GITHUB_ACTOR}@users.noreply.github.com"
+    - name: Release
+      uses: helm/chart-releaser-action@v1.0.0
+      env:
+        CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/charts/redisoperator/Chart.yaml
+++ b/charts/redisoperator/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for the Spotahome Redis Operator
 name: redisoperator
-version: 3.1.0
+version: 3.1.1


### PR DESCRIPTION
Fixes #104

Changes proposed on the PR:

- Use the [Helm Chart Release GH action](https://github.com/marketplace/actions/helm-chart-releaser) to publish GitHub releases, using GitHub Pages to serve the repository index. This avoids having to check the chart archive into the repository as it's published via normal GitHub releases.

⚠️ I've got a couple of test commits on this PR to verify that it's working correctly. If you're happy with the setup, let me know and I'll gladly rebase them out.

Thanks in advance!