### PR TITLE
nodeSelector+tolerations to Operator's Deployment

### DIFF
--- a/charts/redisoperator/templates/deployment.yaml
+++ b/charts/redisoperator/templates/deployment.yaml
@@ -24,6 +24,14 @@ spec:
 {{- if .Values.rbac.install }}
       serviceAccountName: {{ include "name" . | quote }}
 {{- end }}
+{{- with .Values.nodeSelector }}
+      nodeSelector:
+{{- toYaml . | nindent 8 }}
+{{- end }}
+{{- with .Values.tolerations }}
+      tolerations:
+{{- toYaml . | nindent 8 }}
+{{- end }}
       containers:
       - name: "{{ .Values.containerName }}"
         image: {{ include "image" . | quote }}


### PR DESCRIPTION
Optional nodeSelector and tolerations added to the Deployment spec of the Operator.

Allows the Redis Operator to be deployed into a hybrid cluster with mandatory nodeSelectors and/or tolerations.
As the definitions in values.yaml are not mandatory in general, there is no breaking change.

Changes proposed on the PR:
- Add optional nodeSelector to the Deployment spec of the Operator
- Add optional tolerations to the Deployment spec of the Operator