### PR TITLE
sentinel service append metrics port

### DIFF
--- a/operator/redisfailover/service/generator.go
+++ b/operator/redisfailover/service/generator.go
@@ -43,7 +43,7 @@ func generateSentinelService(rf *redisfailoverv1.RedisFailover, labels map[strin
 	selectorLabels := generateSelectorLabels(sentinelRoleName, rf.Name)
 	labels = util.MergeLabels(labels, selectorLabels)
 
-	return &corev1.Service{
+	svc := &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            name,
 			Namespace:       namespace,
@@ -63,6 +63,16 @@ func generateSentinelService(rf *redisfailoverv1.RedisFailover, labels map[strin
 			},
 		},
 	}
+
+	if rf.Spec.Sentinel.Exporter.Enabled {
+		svc.Spec.Ports = append(svc.Spec.Ports, corev1.ServicePort{
+			Name:       "metrics",
+			Port:       sentinelExporterPort,
+			TargetPort: intstr.FromInt(sentinelExporterPort),
+			Protocol:   "TCP",
+		})
+	}
+	return svc
 }
 
 func generateRedisService(rf *redisfailoverv1.RedisFailover, labels map[string]string, ownerRefs []metav1.OwnerReference) *corev1.Service {


### PR DESCRIPTION
Hi,

Sentinel service don't have metrics port when sentinel exporter is configured.

This PR add metrics in the generateSentinelService function.