### PR TITLE
Labels added to mark roles of the Redis Pods as Master and slave

### DIFF
--- a/service/k8s/statefulset.go
+++ b/service/k8s/statefulset.go
@@ -22,6 +22,7 @@ type StatefulSet interface {
 	CreateOrUpdateStatefulSet(namespace string, statefulSet *appsv1.StatefulSet) error
 	DeleteStatefulSet(namespace string, name string) error
 	ListStatefulSets(namespace string) (*appsv1.StatefulSetList, error)
+	GetCoreV1() (kubernetes.Interface)
 }
 
 // StatefulSetService is the service account service implementation using API calls to kubernetes.
@@ -110,4 +111,9 @@ func (s *StatefulSetService) DeleteStatefulSet(namespace, name string) error {
 // ListStatefulSets will retrieve a list of statefulset in the given namespace
 func (s *StatefulSetService) ListStatefulSets(namespace string) (*appsv1.StatefulSetList, error) {
 	return s.kubeClient.AppsV1().StatefulSets(namespace).List(metav1.ListOptions{})
+}
+
+//Returns the kubernetes client interface
+func (s *StatefulSetService) GetCoreV1() ( (kubernetes.Interface)) {
+	return s.kubeClient
 }


### PR DESCRIPTION
Fixes #275 

Changes proposed on the PR:
-  Labels were added to the Redis pods as master and slave depending on the roles, this would be helpful when any user would want to access Redis outside of the Kubernetes cluster. The users would have to expose the Redis pods with the label as `role: Master` and the exposed service would point to the Master Redis pod.