### PR TITLE
Sidecar Support Added in the Redis Pods

### DIFF
--- a/api/redisfailover/v1/types.go
+++ b/api/redisfailover/v1/types.go
@@ -42,6 +42,7 @@ type RedisSettings struct {
 	ShutdownConfigMap    string                        `json:"shutdownConfigMap,omitempty"`
 	Storage              RedisStorage                  `json:"storage,omitempty"`
 	Exporter             RedisExporter                 `json:"exporter,omitempty"`
+	SideCar              []RedisSideCar                 `json:"sidecar,omitempty"`
 	Affinity             *corev1.Affinity              `json:"affinity,omitempty"`
 	SecurityContext      *corev1.PodSecurityContext    `json:"securityContext,omitempty"`
 	ImagePullSecrets     []corev1.LocalObjectReference `json:"imagePullSecrets,omitempty"`
@@ -94,6 +95,14 @@ type RedisExporter struct {
 	ImagePullPolicy corev1.PullPolicy `json:"imagePullPolicy,omitempty"`
 }
 
+// RedisSideCar defines the specification for the redis SideCar
+type RedisSideCar struct {
+    Name            string            `json:"name"`
+	Image           string            `json:"image,omitempty"`
+	ImagePullPolicy corev1.PullPolicy `json:"imagePullPolicy,omitempty"`
+ 	Command         []string          `json:"command,omitempty"`
+ 	Port            int32             `json:"port,omitempty"`
+}
 // SentinelExporter defines the specification for the sentinel exporter
 type SentinelExporter struct {
 	Enabled         bool              `json:"enabled,omitempty"`

--- a/operator/redisfailover/service/constants.go
+++ b/operator/redisfailover/service/constants.go
@@ -9,6 +9,7 @@ const (
 const (
 	exporterPort                  = 9121
 	sentinelExporterPort          = 9355
+	SideCarPort                   = 80
 	exporterPortName              = "http-metrics"
 	exporterContainerName         = "redis-exporter"
 	sentinelExporterContainerName = "sentinel-exporter"


### PR DESCRIPTION
Fixes #187 

Changes proposed on the PR:
- SideCar support functionality added in this PR. Users can add `n` number of sidecars to the Redis cluster. An example usage is demonstrated below:
```
apiVersion: databases.spotahome.com/v1
kind: RedisFailover
metadata:
  ....
spec:
  sentinel:
    image: ...
    replicas: 3
  redis:
    image: ...
    replicas: 3
    sidecar:
    - image: docker_image_1
      name: name_1
    - image: docker_image_2
      name: name_2
      .
      .
      .
    - image: docker_image_n
      name: name_n
```
`sidecar` also supports port, ImagePullPolicy, and command. For example:
```
sidecar:
    - image: docker_image_1 // docker image of sidecar
      name: name_1 // name of the sidecar image 
      imagePullPolicy: imagePullPolicy_1 
      port: port_1 // port number of the sidecar container, if this is not mentioned the container takes default port 80
      command: command_1  // command to be executed by the sidecar image when started 
```