### PR TITLE
Increase FailureThreshold to 6 for redis instances

### DIFF
--- a/operator/redisfailover/service/generator.go
+++ b/operator/redisfailover/service/generator.go
@@ -303,6 +303,8 @@ func generateRedisStatefulSet(rf *redisfailoverv1.RedisFailover, labels map[stri
 							LivenessProbe: &corev1.Probe{
 								InitialDelaySeconds: graceTime,
 								TimeoutSeconds:      5,
+								FailureThreshold:    6,
+								PeriodSeconds:       15,
 								Handler: corev1.Handler{
 									Exec: &corev1.ExecAction{
 										Command: []string{
@@ -540,14 +542,14 @@ func createRedisExporterContainer(rf *redisfailoverv1.RedisFailover) corev1.Cont
 		Image:           rf.Spec.Redis.Exporter.Image,
 		ImagePullPolicy: pullPolicy(rf.Spec.Redis.Exporter.ImagePullPolicy),
 		Args:            rf.Spec.Redis.Exporter.Args,
-		Env:             append(rf.Spec.Redis.Exporter.Env, corev1.EnvVar{
-				Name: "REDIS_ALIAS",
-				ValueFrom: &corev1.EnvVarSource{
-					FieldRef: &corev1.ObjectFieldSelector{
-						FieldPath: "metadata.name",
-					},
+		Env: append(rf.Spec.Redis.Exporter.Env, corev1.EnvVar{
+			Name: "REDIS_ALIAS",
+			ValueFrom: &corev1.EnvVarSource{
+				FieldRef: &corev1.ObjectFieldSelector{
+					FieldPath: "metadata.name",
 				},
 			},
+		},
 		),
 		Ports: []corev1.ContainerPort{
 			{


### PR DESCRIPTION
### Description

For some large datasets, redis take some time to load them in memory. During this time redis is blocked and unresponsive even for ping command which can potentially let the instance in a crashloopback state because the kills from liveness probe.
Increasing the Failure threshold will let time for dataset to be loaded while the cluster is protected by readiness probe and sentinels.

 * Increase Failure threshold to be less aggressive in liveness probe 