### PR TITLE
distinguish master and slave

### DIFF
--- a/operator/redisfailover/ensurer.go
+++ b/operator/redisfailover/ensurer.go
@@ -18,16 +18,6 @@ func (w *RedisFailoverHandler) Ensure(rf *redisfailoverv1.RedisFailover, labels 
 		}
 	}
 
-	sentinelsAllowed := rf.SentinelsAllowed()
-	if sentinelsAllowed {
-		if err := w.rfService.EnsureSentinelService(rf, labels, or); err != nil {
-			return err
-		}
-		if err := w.rfService.EnsureSentinelConfigMap(rf, labels, or); err != nil {
-			return err
-		}
-	}
-
 	if err := w.rfService.EnsureRedisShutdownConfigMap(rf, labels, or); err != nil {
 		return err
 	}
@@ -41,11 +31,18 @@ func (w *RedisFailoverHandler) Ensure(rf *redisfailoverv1.RedisFailover, labels 
 		return err
 	}
 
-	if sentinelsAllowed {
+	if rf.SentinelsAllowed() {
+		if err := w.rfService.EnsureSentinelService(rf, labels, or); err != nil {
+			return err
+		}
+		if err := w.rfService.EnsureSentinelConfigMap(rf, labels, or); err != nil {
+			return err
+		}
 		if err := w.rfService.EnsureSentinelDeployment(rf, labels, or); err != nil {
 			return err
 		}
 	}
+	// TODO: if not allowed sentinel delete resources related
 
 	return nil
 }

--- a/operator/redisfailover/service/constants.go
+++ b/operator/redisfailover/service/constants.go
@@ -24,6 +24,8 @@ const (
 	bootstrapName          = "b"
 	sentinelName           = "s"
 	sentinelRoleName       = "sentinel"
+	masterRoleName         = "master"
+	slaveRoleName          = "slave"
 	sentinelConfigFileName = "sentinel.conf"
 	redisConfigFileName    = "redis.conf"
 	redisName              = "r"

--- a/operator/redisfailover/service/names.go
+++ b/operator/redisfailover/service/names.go
@@ -14,6 +14,11 @@ func GetRedisShutdownConfigMapName(rf *redisfailoverv1.RedisFailover) string {
 	return GetRedisShutdownName(rf)
 }
 
+// GetRedisNameByRole returns the name for redis master or slave resources
+func GetRedisNameByRole(rf *redisfailoverv1.RedisFailover, role string) string {
+	return generateName(redisName, rf.Name+"-"+role)
+}
+
 // GetRedisName returns the name for redis resources
 func GetRedisName(rf *redisfailoverv1.RedisFailover) string {
 	return generateName(redisName, rf.Name)


### PR DESCRIPTION
Fixes #275

Changes proposed on the PR:

in order to achieve read/write separation, Labels were added to the Redis pods as master and slave depending on the roles,and will create the service point to master and slave,users can access different service to achieve read and write separation