### PR TITLE
add terminationGracePeriodSeconds option

### DIFF
--- a/api/redisfailover/v1/types.go
+++ b/api/redisfailover/v1/types.go
@@ -32,27 +32,28 @@ type RedisCommandRename struct {
 
 // RedisSettings defines the specification of the redis cluster
 type RedisSettings struct {
-	Image                string                        `json:"image,omitempty"`
-	ImagePullPolicy      corev1.PullPolicy             `json:"imagePullPolicy,omitempty"`
-	Replicas             int32                         `json:"replicas,omitempty"`
-	Resources            corev1.ResourceRequirements   `json:"resources,omitempty"`
-	CustomConfig         []string                      `json:"customConfig,omitempty"`
-	CustomCommandRenames []RedisCommandRename          `json:"customCommandRenames,omitempty"`
-	Command              []string                      `json:"command,omitempty"`
-	ShutdownConfigMap    string                        `json:"shutdownConfigMap,omitempty"`
-	Storage              RedisStorage                  `json:"storage,omitempty"`
-	Exporter             RedisExporter                 `json:"exporter,omitempty"`
-	Affinity             *corev1.Affinity              `json:"affinity,omitempty"`
-	SecurityContext      *corev1.PodSecurityContext    `json:"securityContext,omitempty"`
-	ImagePullSecrets     []corev1.LocalObjectReference `json:"imagePullSecrets,omitempty"`
-	Tolerations          []corev1.Toleration           `json:"tolerations,omitempty"`
-	NodeSelector         map[string]string             `json:"nodeSelector,omitempty"`
-	PodAnnotations       map[string]string             `json:"podAnnotations,omitempty"`
-	ServiceAnnotations   map[string]string             `json:"serviceAnnotations,omitempty"`
-	HostNetwork          bool                          `json:"hostNetwork,omitempty"`
-	DNSPolicy            corev1.DNSPolicy              `json:"dnsPolicy,omitempty"`
-	PriorityClassName    string                        `json:"priorityClassName,omitempty"`
-	ServiceAccountName   string                        `json:"serviceAccountName,omitempty"`
+	Image                         string                        `json:"image,omitempty"`
+	ImagePullPolicy               corev1.PullPolicy             `json:"imagePullPolicy,omitempty"`
+	Replicas                      int32                         `json:"replicas,omitempty"`
+	Resources                     corev1.ResourceRequirements   `json:"resources,omitempty"`
+	CustomConfig                  []string                      `json:"customConfig,omitempty"`
+	CustomCommandRenames          []RedisCommandRename          `json:"customCommandRenames,omitempty"`
+	Command                       []string                      `json:"command,omitempty"`
+	ShutdownConfigMap             string                        `json:"shutdownConfigMap,omitempty"`
+	Storage                       RedisStorage                  `json:"storage,omitempty"`
+	Exporter                      RedisExporter                 `json:"exporter,omitempty"`
+	Affinity                      *corev1.Affinity              `json:"affinity,omitempty"`
+	SecurityContext               *corev1.PodSecurityContext    `json:"securityContext,omitempty"`
+	ImagePullSecrets              []corev1.LocalObjectReference `json:"imagePullSecrets,omitempty"`
+	Tolerations                   []corev1.Toleration           `json:"tolerations,omitempty"`
+	NodeSelector                  map[string]string             `json:"nodeSelector,omitempty"`
+	PodAnnotations                map[string]string             `json:"podAnnotations,omitempty"`
+	ServiceAnnotations            map[string]string             `json:"serviceAnnotations,omitempty"`
+	HostNetwork                   bool                          `json:"hostNetwork,omitempty"`
+	DNSPolicy                     corev1.DNSPolicy              `json:"dnsPolicy,omitempty"`
+	PriorityClassName             string                        `json:"priorityClassName,omitempty"`
+	ServiceAccountName            string                        `json:"serviceAccountName,omitempty"`
+	TerminationGracePeriodSeconds int64                         `json:"terminationGracePeriod,omitempty"`
 }
 
 // SentinelSettings defines the specification of the sentinel cluster


### PR DESCRIPTION
Fixes #270 

Changes proposed on the PR:
- add custom terminationGracePeriodSeconds on redis

For us this is useful because at it stands the statefulset restarts before redis slave is up. In some of our environments we have only one slave which leads to downtime. We have shutdown script which waits for new slave to be up, but terminationGracePeriodSeconds is too low to and pod restarts anyway

Thanks!