### PR TITLE
fix: update clusterrole template to be compatible with openshift

### DIFF
--- a/charts/redisoperator/templates/rbac.yaml
+++ b/charts/redisoperator/templates/rbac.yaml
@@ -48,6 +48,8 @@ rules:
       - endpoints
       - events
       - configmaps
+      - persistentvolumeclaims
+      - persistentvolumeclaims/finalizers
     verbs:
       - create
       - delete

--- a/example/operator/all-redis-operator-resources.yaml
+++ b/example/operator/all-redis-operator-resources.yaml
@@ -56,6 +56,7 @@ rules:
       - databases.spotahome.com
     resources:
       - redisfailovers
+      - redisfailovers/finalizers
     verbs:
       - "*"
   - apiGroups:
@@ -72,6 +73,8 @@ rules:
       - endpoints
       - events
       - configmaps
+      - persistentvolumeclaims
+      - persistentvolumeclaims/finalizers
     verbs:
       - "*"
   - apiGroups:

--- a/example/operator/roles.yaml
+++ b/example/operator/roles.yaml
@@ -7,6 +7,7 @@ rules:
       - databases.spotahome.com
     resources:
       - redisfailovers
+      - redisfailovers/finalizers
     verbs:
       - "*"
   - apiGroups:
@@ -24,6 +25,8 @@ rules:
       - events
       - configmaps
       - secrets
+      - persistentvolumeclaims
+      - persistentvolumeclaims/finalizers
     verbs:
       - "*"
   - apiGroups:


### PR DESCRIPTION
Signed-off-by: chlins <chenyuzh@vmware.com>

Fixes https://github.com/spotahome/redis-operator/issues/98

Changes proposed on the PR:
-  add  `persistentvolumeclaims/finalizers` to role resources
-  manifest yaml under examples folder was out of date, sync with charts