### PR TITLE
Fix static code checker issues

### DIFF
--- a/cmd/redisoperator/main.go
+++ b/cmd/redisoperator/main.go
@@ -54,7 +54,10 @@ func (m *Main) Run() error {
 
 	// Set correct logging.
 	if m.flags.Debug {
-		m.logger.Set("debug")
+		err := m.logger.Set("debug")
+		if err != nil {
+			return err
+		}
 		m.logger.Debugf("debug mode activated")
 	}
 
@@ -66,7 +69,10 @@ func (m *Main) Run() error {
 	// Serve metrics.
 	go func() {
 		log.Infof("Listening on %s for metrics exposure", m.flags.ListenAddr)
-		http.ListenAndServe(m.flags.ListenAddr, nil)
+		err := http.ListenAndServe(m.flags.ListenAddr, nil)
+		if err != nil {
+			log.Fatal(err)
+		}
 	}()
 
 	// Kubernetes clients.

--- a/cmd/redisoperator/main.go
+++ b/cmd/redisoperator/main.go
@@ -11,7 +11,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	kmetrics "github.com/spotahome/kooper/monitoring/metrics"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/oidc"
-	"k8s.io/client-go/rest"
 
 	"github.com/spotahome/redis-operator/cmd/utils"
 	"github.com/spotahome/redis-operator/log"
@@ -28,10 +27,9 @@ const (
 
 // Main is the  main runner.
 type Main struct {
-	flags     *utils.CMDFlags
-	k8sConfig rest.Config
-	logger    log.Logger
-	stopC     chan struct{}
+	flags  *utils.CMDFlags
+	logger log.Logger
+	stopC  chan struct{}
 }
 
 // New returns a Main object.

--- a/operator/redisfailover/checker.go
+++ b/operator/redisfailover/checker.go
@@ -53,7 +53,10 @@ func (r *RedisFailoverHandler) UpdateRedisesPods(rf *redisfailoverv1.RedisFailov
 		}
 		if revision != ssUR {
 			//Delete pod and wait next round to check if the new one is synced
-			r.rfHealer.DeletePod(pod, rf)
+			err = r.rfHealer.DeletePod(pod, rf)
+			if err != nil {
+				return err
+			}
 			return nil
 		}
 	}
@@ -66,8 +69,14 @@ func (r *RedisFailoverHandler) UpdateRedisesPods(rf *redisfailoverv1.RedisFailov
 		}
 
 		masterRevision, err := r.rfChecker.GetRedisRevisionHash(master, rf)
+		if err != nil {
+			return err
+		}
 		if masterRevision != ssUR {
-			r.rfHealer.DeletePod(master, rf)
+			err = r.rfHealer.DeletePod(master, rf)
+			if err != nil {
+				return err
+			}
 			return nil
 		}
 	}

--- a/operator/redisfailover/checker_test.go
+++ b/operator/redisfailover/checker_test.go
@@ -874,7 +874,7 @@ func TestUpdate(t *testing.T) {
 						}
 					}
 				}
-				fmt.Println(fmt.Sprintf("%v - %v", test.name, next))
+				fmt.Printf("%v - %v\n", test.name, next)
 				if next && !test.bootstrapping {
 					if test.noMaster {
 						mrfc.On("GetRedisesMasterPod", rf).Once().Return("", errors.New(""))

--- a/operator/redisfailover/ensurer_test.go
+++ b/operator/redisfailover/ensurer_test.go
@@ -18,10 +18,6 @@ import (
 const (
 	name      = "test"
 	namespace = "testns"
-
-	bootstrapName = "rfb-test"
-	sentinelName  = "rfs-test"
-	redisName     = "rfr-test"
 )
 
 func generateConfig() rfOperator.Config {

--- a/operator/redisfailover/service/check.go
+++ b/operator/redisfailover/service/check.go
@@ -233,7 +233,7 @@ func (r *RedisFailoverChecker) GetMinimumRedisPodTime(rf *redisfailoverv1.RedisF
 			continue
 		}
 		start := redisNode.Status.StartTime.Round(time.Second)
-		alive := time.Now().Sub(start)
+		alive := time.Since(start)
 		r.logger.Debugf("Pod %s has been alive for %.f seconds", redisNode.Status.PodIP, alive.Seconds())
 		if alive < minTime {
 			minTime = alive
@@ -325,7 +325,7 @@ func (r *RedisFailoverChecker) GetRedisRevisionHash(podName string, rFailover *r
 		return "", errors.New("labels not found")
 	}
 
-	val, _ := pod.ObjectMeta.Labels[appsv1.ControllerRevisionHashLabelKey]
+	val := pod.ObjectMeta.Labels[appsv1.ControllerRevisionHashLabelKey]
 
 	return val, nil
 }

--- a/operator/redisfailover/service/constants.go
+++ b/operator/redisfailover/service/constants.go
@@ -1,10 +1,5 @@
 package service
 
-const (
-	logNameField      = "redisfailover"
-	logNamespaceField = "namespace"
-)
-
 // variables refering to the redis exporter port
 const (
 	exporterPort                  = 9121
@@ -19,9 +14,7 @@ const (
 )
 
 const (
-	description            = "Manage a Redis Failover deployment"
 	baseName               = "rf"
-	bootstrapName          = "b"
 	sentinelName           = "s"
 	sentinelRoleName       = "sentinel"
 	sentinelConfigFileName = "sentinel.conf"
@@ -30,7 +23,6 @@ const (
 	redisShutdownName      = "r-s"
 	redisReadinessName     = "r-readiness"
 	redisRoleName          = "redis"
-	redisGroupName         = "mymaster"
 	appLabel               = "redis-failover"
 	hostnameTopologyKey    = "kubernetes.io/hostname"
 )

--- a/operator/redisfailover/service/constants_test.go
+++ b/operator/redisfailover/service/constants_test.go
@@ -1,6 +1,8 @@
 package service_test
 
 const (
-	name      = "test"
-	namespace = "testns"
+	name         = "test"
+	namespace    = "testns"
+	sentinelName = "rfs-test"
+	redisName    = "rfr-test"
 )

--- a/operator/redisfailover/service/constants_test.go
+++ b/operator/redisfailover/service/constants_test.go
@@ -3,8 +3,4 @@ package service_test
 const (
 	name      = "test"
 	namespace = "testns"
-
-	bootstrapName = "rfb-test"
-	sentinelName  = "rfs-test"
-	redisName     = "rfr-test"
 )

--- a/operator/redisfailover/service/generator.go
+++ b/operator/redisfailover/service/generator.go
@@ -525,17 +525,6 @@ func generatePodDisruptionBudget(name string, namespace string, labels map[strin
 	}
 }
 
-func generateResourceList(cpu string, memory string) corev1.ResourceList {
-	resources := corev1.ResourceList{}
-	if cpu != "" {
-		resources[corev1.ResourceCPU], _ = resource.ParseQuantity(cpu)
-	}
-	if memory != "" {
-		resources[corev1.ResourceMemory], _ = resource.ParseQuantity(memory)
-	}
-	return resources
-}
-
 func createRedisExporterContainer(rf *redisfailoverv1.RedisFailover) corev1.Container {
 	container := corev1.Container{
 		Name:            exporterContainerName,

--- a/operator/redisfailover/util/label.go
+++ b/operator/redisfailover/util/label.go
@@ -5,10 +5,8 @@ func MergeLabels(allLabels ...map[string]string) map[string]string {
 	res := map[string]string{}
 
 	for _, labels := range allLabels {
-		if labels != nil {
-			for k, v := range labels {
-				res[k] = v
-			}
+		for k, v := range labels {
+			res[k] = v
 		}
 	}
 	return res

--- a/service/k8s/secret_test.go
+++ b/service/k8s/secret_test.go
@@ -10,18 +10,9 @@ import (
 	errors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	kubernetes "k8s.io/client-go/kubernetes/fake"
 	kubetesting "k8s.io/client-go/testing"
 )
-
-var (
-	secretsGroup = schema.GroupVersionResource{Group: "", Version: "v1", Resource: "secrets"}
-)
-
-func newSecretGetAction(ns, name string) kubetesting.GetActionImpl {
-	return kubetesting.NewGetAction(secretsGroup, ns, name)
-}
 
 func TestSecretServiceGet(t *testing.T) {
 

--- a/service/redis/client.go
+++ b/service/redis/client.go
@@ -192,9 +192,20 @@ func (c *client) MonitorRedisWithPort(ip, monitor, port, quorum, password string
 	if err != nil {
 		return err
 	}
+	err = rClient.Process(cmd)
+	if err != nil {
+		return err
+	}
 	// We'll continue even if it fails, the priority is to have the redises monitored
 	cmd = rediscli.NewBoolCmd("SENTINEL", "MONITOR", masterName, monitor, port, quorum)
-	rClient.Process(cmd)
+	err = rClient.Process(cmd)
+	if err != nil {
+		return err
+	}
+	err = rClient.Process(cmd)
+	if err != nil {
+		return err
+	}
 	_, err = cmd.Result()
 	if err != nil {
 		return err
@@ -255,7 +266,10 @@ func (c *client) GetSentinelMonitor(ip string) (string, string, error) {
 	rClient := rediscli.NewClient(options)
 	defer rClient.Close()
 	cmd := rediscli.NewSliceCmd("SENTINEL", "master", masterName)
-	rClient.Process(cmd)
+	err := rClient.Process(cmd)
+	if err != nil {
+		return "", "", err
+	}
 	res, err := cmd.Result()
 	if err != nil {
 		return "", "", err
@@ -314,7 +328,10 @@ func (c *client) applyRedisConfig(parameter string, value string, rClient *redis
 
 func (c *client) applySentinelConfig(parameter string, value string, rClient *rediscli.Client) error {
 	cmd := rediscli.NewStatusCmd("SENTINEL", "set", masterName, parameter, value)
-	rClient.Process(cmd)
+	err := rClient.Process(cmd)
+	if err != nil {
+		return err
+	}
 	return cmd.Err()
 }
 

--- a/service/redis/client.go
+++ b/service/redis/client.go
@@ -129,8 +129,11 @@ func (c *client) ResetSentinel(ip string) error {
 	rClient := rediscli.NewClient(options)
 	defer rClient.Close()
 	cmd := rediscli.NewIntCmd("SENTINEL", "reset", "*")
-	rClient.Process(cmd)
-	_, err := cmd.Result()
+	err := rClient.Process(cmd)
+	if err != nil {
+		return err
+	}
+	_, err = cmd.Result()
 	if err != nil {
 		return err
 	}
@@ -185,18 +188,24 @@ func (c *client) MonitorRedisWithPort(ip, monitor, port, quorum, password string
 	rClient := rediscli.NewClient(options)
 	defer rClient.Close()
 	cmd := rediscli.NewBoolCmd("SENTINEL", "REMOVE", masterName)
-	rClient.Process(cmd)
+	err := rClient.Process(cmd)
+	if err != nil {
+		return err
+	}
 	// We'll continue even if it fails, the priority is to have the redises monitored
 	cmd = rediscli.NewBoolCmd("SENTINEL", "MONITOR", masterName, monitor, port, quorum)
 	rClient.Process(cmd)
-	_, err := cmd.Result()
+	_, err = cmd.Result()
 	if err != nil {
 		return err
 	}
 
 	if password != "" {
 		cmd = rediscli.NewBoolCmd("SENTINEL", "SET", masterName, "auth-pass", password)
-		rClient.Process(cmd)
+		err := rClient.Process(cmd)
+		if err != nil {
+			return err
+		}
 		_, err = cmd.Result()
 		if err != nil {
 			return err


### PR DESCRIPTION
* Remove dead code
* Add error checking
* Use simple-go recommendations
```
service/k8s/secret_test.go:22:6: `newSecretGetAction` is unused (deadcode)
func newSecretGetAction(ns, name string) kubetesting.GetActionImpl {
     ^
operator/redisfailover/service/constants.go:4:2: `logNameField` is unused (deadcode)
	logNameField      = "redisfailover"
	^
operator/redisfailover/service/constants.go:5:2: `logNamespaceField` is unused (deadcode)
	logNamespaceField = "namespace"
	^
operator/redisfailover/service/constants.go:22:2: `description` is unused (deadcode)
	description            = "Manage a Redis Failover deployment"
	^
operator/redisfailover/service/constants.go:24:2: `bootstrapName` is unused (deadcode)
	bootstrapName          = "b"
	^
operator/redisfailover/service/constants.go:33:2: `redisGroupName` is unused (deadcode)
	redisGroupName         = "mymaster"
	^
operator/redisfailover/service/generator.go:528:6: `generateResourceList` is unused (deadcode)
func generateResourceList(cpu string, memory string) corev1.ResourceList {
     ^
operator/redisfailover/service/constants_test.go:7:2: `bootstrapName` is unused (deadcode)
	bootstrapName = "rfb-test"
	^
operator/redisfailover/ensurer_test.go:22:2: `bootstrapName` is unused (deadcode)
	bootstrapName = "rfb-test"
	^
operator/redisfailover/ensurer_test.go:23:2: `sentinelName` is unused (deadcode)
	sentinelName  = "rfs-test"
	^
operator/redisfailover/ensurer_test.go:24:2: `redisName` is unused (deadcode)
	redisName     = "rfr-test"
	^
service/redis/client.go:132:17: Error return value of `rClient.Process` is not checked (errcheck)
	rClient.Process(cmd)
	               ^
service/redis/client.go:188:17: Error return value of `rClient.Process` is not checked (errcheck)
	rClient.Process(cmd)
	               ^
service/redis/client.go:191:17: Error return value of `rClient.Process` is not checked (errcheck)
	rClient.Process(cmd)
	               ^
operator/redisfailover/checker.go:56:24: Error return value of `r.rfHealer.DeletePod` is not checked (errcheck)
			r.rfHealer.DeletePod(pod, rf)
			                    ^
operator/redisfailover/checker.go:70:24: Error return value of `r.rfHealer.DeletePod` is not checked (errcheck)
			r.rfHealer.DeletePod(master, rf)
			                    ^
cmd/redisoperator/main.go:57:15: Error return value of `m.logger.Set` is not checked (errcheck)
		m.logger.Set("debug")
		            ^
cmd/redisoperator/main.go:69:22: Error return value of `http.ListenAndServe` is not checked (errcheck)
		http.ListenAndServe(m.flags.ListenAddr, nil)
		                   ^
cmd/redisoperator/main.go:32:2: `k8sConfig` is unused (structcheck)
	k8sConfig rest.Config
	^
operator/redisfailover/service/check.go:328:2: S1005: unnecessary assignment to the blank identifier (gosimple)
	val, _ := pod.ObjectMeta.Labels[appsv1.ControllerRevisionHashLabelKey]
	^
operator/redisfailover/util/label.go:8:3: S1031: unnecessary nil check around range (gosimple)
		if labels != nil {
		^
operator/redisfailover/checker_test.go:877:5: S1038: should use fmt.Printf instead of fmt.Println(fmt.Sprintf(...)) (but don't forget the newline) (gosimple)
				fmt.Println(fmt.Sprintf("%v - %v", test.name, next))
				^
operator/redisfailover/service/check.go:236:12: S1012: should use `time.Since` instead of `time.Now().Sub` (gosimple)
		alive := time.Now().Sub(start)
		         ^
operator/redisfailover/checker.go:68:19: ineffectual assignment to err (ineffassign)
		masterRevision, err := r.rfChecker.GetRedisRevisionHash(master, rf)
		                ^
```