### PR TITLE
Add Integration test to run with github-actions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -30,6 +30,8 @@ jobs:
       - uses: actions/setup-go@v2
         with:
           go-version: 1.17
+      - name: Install conntrack
+        run: sudo apt-get install -y conntrack
       - uses: medyagh/setup-minikube@v0.0.7
         with:
           kubernetes-version: 1.22.2

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -36,4 +36,6 @@ jobs:
         with:
           kubernetes-version: 1.22.2
           driver: none
+      - name: Add redisfailover CRD
+        run: kubectl apply -f manifests/databases.spotahome.com_redisfailovers.yaml
       - run: make ci-integration-test

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,3 +21,17 @@ jobs:
         with:
           go-version: 1.17
       - run: make ci-unit-test
+
+  integration-test:
+    name: Integration test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-go@v2
+        with:
+          go-version: 1.17
+      - uses: medyagh/setup-minikube@v0.0.7
+        with:
+          kubernetes-version: 1.22.2
+          driver: none
+      - run: make ci-integration-test

--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,7 @@ PORT := 9710
 # CMDs
 UNIT_TEST_CMD := go test `go list ./... | grep -v /vendor/` -v
 GO_GENERATE_CMD := go generate `go list ./... | grep -v /vendor/`
+GO_INTEGRATION_TEST_CMD := go list ./... | grep test/integration` -v -tags='integration'
 GET_DEPS_CMD := dep ensure
 UPDATE_DEPS_CMD := dep ensure
 MOCKS_CMD := go generate ./mocks
@@ -112,6 +113,10 @@ unit-test: docker-build
 ci-unit-test:
 	$(UNIT_TEST_CMD)
 
+.PHONY: ci-integration-test
+ci-integration-test:
+	$(GO_INTEGRATION_TEST_CMD)
+
 .PHONY: integration-test
 integration-test:
 	./scripts/integration-tests.sh
@@ -122,7 +127,7 @@ helm-test:
 
 # Run all tests
 .PHONY: test
-test: ci-unit-test integration-test helm-test
+test: ci-unit-test ci-integration-test helm-test
 
 .PHONY: go-generate
 go-generate: docker-build

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ PORT := 9710
 # CMDs
 UNIT_TEST_CMD := go test `go list ./... | grep -v /vendor/` -v
 GO_GENERATE_CMD := go generate `go list ./... | grep -v /vendor/`
-GO_INTEGRATION_TEST_CMD := go list ./... | grep test/integration` -v -tags='integration'
+GO_INTEGRATION_TEST_CMD := go test `go list ./... | grep test/integration` -v -tags='integration'
 GET_DEPS_CMD := dep ensure
 UPDATE_DEPS_CMD := dep ensure
 MOCKS_CMD := go generate ./mocks

--- a/cmd/redisoperator/main.go
+++ b/cmd/redisoperator/main.go
@@ -61,7 +61,6 @@ func (m *Main) Run() error {
 
 	// Create the metrics client.
 	metricsRecorder := metrics.NewRecorder(metricsNamespace, prometheus.DefaultRegisterer)
-	//kooperMetricsServer := kmetrics.NewPrometheus(registry)
 
 	// Serve metrics.
 	go func() {

--- a/metrics/dummy.go
+++ b/metrics/dummy.go
@@ -1,9 +1,13 @@
 package metrics
 
-import koopercontroller "github.com/spotahome/kooper/v2/controller"
+import (
+	koopercontroller "github.com/spotahome/kooper/v2/controller"
+)
 
 // Dummy is a handy instnce of a dummy instrumenter, most of the times it will be used on tests.
-var Dummy = &dummy{}
+var Dummy = &dummy{
+	MetricsRecorder: koopercontroller.DummyMetricsRecorder,
+}
 
 // dummy is a dummy implementation of Instrumenter.
 type dummy struct {

--- a/scripts/integration-tests.sh
+++ b/scripts/integration-tests.sh
@@ -15,7 +15,7 @@ function cleanup {
 trap cleanup EXIT
 
 echo "=> Preparing minikube for running integration tests"
-$SUDO minikube start --vm-driver=none --kubernetes-version=v1.15.6
+$SUDO minikube start --vm-driver=none --kubernetes-version=v1.22.3
 
 echo "=> Waiting for minikube to start"
 sleep 30

--- a/service/redis/client.go
+++ b/service/redis/client.go
@@ -188,21 +188,10 @@ func (c *client) MonitorRedisWithPort(ip, monitor, port, quorum, password string
 	rClient := rediscli.NewClient(options)
 	defer rClient.Close()
 	cmd := rediscli.NewBoolCmd("SENTINEL", "REMOVE", masterName)
-	err := rClient.Process(cmd)
-	if err != nil {
-		return err
-	}
-	err = rClient.Process(cmd)
-	if err != nil {
-		return err
-	}
+	_ = rClient.Process(cmd)
 	// We'll continue even if it fails, the priority is to have the redises monitored
 	cmd = rediscli.NewBoolCmd("SENTINEL", "MONITOR", masterName, monitor, port, quorum)
-	err = rClient.Process(cmd)
-	if err != nil {
-		return err
-	}
-	err = rClient.Process(cmd)
+	err := rClient.Process(cmd)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
After Travis close we lost integration test runs in CI.

* Update integration tests client-go functions
* Fix redis client 
* Add integration test to github-actions workflow