### PR TITLE
Helm chart releaser workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   check:
-    name: Check
+    name: Golang Check
     runs-on: ubuntu-latest
     # Execute the checks inside the container instead the VM.
     container: golangci/golangci-lint:v1.43.0-alpine
@@ -39,3 +39,19 @@ jobs:
       - name: Add redisfailover CRD
         run: kubectl apply -f manifests/databases.spotahome.com_redisfailovers.yaml
       - run: make ci-integration-test
+
+  chart-test:
+    name: Chart testing
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Install Helm
+        uses: azure/setup-helm@v1
+        with:
+          version: v3.7.2
+
+      - name: Helm test
+        run: make helm-test

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,10 @@
 name: CI
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
 
 jobs:
   check:

--- a/.github/workflows/helm.yml
+++ b/.github/workflows/helm.yml
@@ -1,22 +1,31 @@
-name: Helm
+name: Release Charts
 
 on:
   push:
     branches:
-    - master
+      - master
 
 jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-      with:
-        fetch-depth: 0
-    - name: Configure Git
-      run: |
-        git config user.name "$GITHUB_ACTOR"
-        git config user.email "${GITHUB_ACTOR}@users.noreply.github.com"
-    - name: Release
-      uses: helm/chart-releaser-action@v1.0.0
-      env:
-        CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Configure Git
+        run: |
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "${GITHUB_ACTOR}@users.noreply.github.com"
+
+      - name: Install Helm
+        uses: azure/setup-helm@v1
+        with:
+          version: v3.7.2
+
+      - name: Release
+        uses: helm/chart-releaser-action@v1.2.1
+        with:
+          charts_dir: charts
+          config: charts/chart-release-config.yaml
+        env:
+          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/helm.yml
+++ b/.github/workflows/helm.yml
@@ -1,0 +1,22 @@
+name: Helm
+
+on:
+  push:
+    branches:
+    - master
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+    - name: Configure Git
+      run: |
+        git config user.name "$GITHUB_ACTOR"
+        git config user.email "${GITHUB_ACTOR}@users.noreply.github.com"
+    - name: Release
+      uses: helm/chart-releaser-action@v1.0.0
+      env:
+        CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/README.md
+++ b/README.md
@@ -39,7 +39,9 @@ This will create a deployment named `redisoperator`.
 From the root folder of the project, execute the following:
 
 ```
-helm install --name redisfailover charts/redisoperator
+helm repo add redis-operator https://spotahome.github.io/redis-operator
+helm repo update
+helm install redis-operator redis-operator/redis-operator
 ```
 
 ## Usage

--- a/charts/chart-release-config.yaml
+++ b/charts/chart-release-config.yaml
@@ -1,0 +1,1 @@
+release-name-template: Chart-{{ .Version }}

--- a/charts/redisoperator/Chart.yaml
+++ b/charts/redisoperator/Chart.yaml
@@ -5,7 +5,6 @@ apiVersion: v1
 description: A Helm chart for the Spotahome Redis Operator
 name: redis-operator
 version: 3.1.2
-engine: gotpl
 home: https://github.com/spotahome/redis-operator
 keywords:
   - "golang"


### PR DESCRIPTION
Fixes #292 authored by @LukeCarrier 

Changes proposed on the PR:

- Use the [Helm Chart Release GH action](https://github.com/marketplace/actions/helm-chart-releaser) to publish GitHub releases, using GitHub Pages to serve the repository index. This avoids having to check the chart archive into the repository as it's published via normal GitHub releases.

Thanks in advance!