### PR TITLE
Allow configuration of exporter resource requirements

### DIFF
--- a/api/redisfailover/v1/types.go
+++ b/api/redisfailover/v1/types.go
@@ -97,20 +97,22 @@ type BootstrapSettings struct {
 
 // RedisExporter defines the specification for the redis exporter
 type RedisExporter struct {
-	Enabled         bool              `json:"enabled,omitempty"`
-	Image           string            `json:"image,omitempty"`
-	ImagePullPolicy corev1.PullPolicy `json:"imagePullPolicy,omitempty"`
-	Args            []string          `json:"args,omitempty"`
-	Env             []corev1.EnvVar   `json:"env,omitempty"`
+	Enabled         bool                         `json:"enabled,omitempty"`
+	Image           string                       `json:"image,omitempty"`
+	ImagePullPolicy corev1.PullPolicy            `json:"imagePullPolicy,omitempty"`
+	Args            []string                     `json:"args,omitempty"`
+	Env             []corev1.EnvVar              `json:"env,omitempty"`
+	Resources       *corev1.ResourceRequirements `json:"resources,omitempty"`
 }
 
 // SentinelExporter defines the specification for the sentinel exporter
 type SentinelExporter struct {
-	Enabled         bool              `json:"enabled,omitempty"`
-	Image           string            `json:"image,omitempty"`
-	ImagePullPolicy corev1.PullPolicy `json:"imagePullPolicy,omitempty"`
-	Args            []string          `json:"args,omitempty"`
-	Env             []corev1.EnvVar   `json:"env,omitempty"`
+	Enabled         bool                         `json:"enabled,omitempty"`
+	Image           string                       `json:"image,omitempty"`
+	ImagePullPolicy corev1.PullPolicy            `json:"imagePullPolicy,omitempty"`
+	Args            []string                     `json:"args,omitempty"`
+	Env             []corev1.EnvVar              `json:"env,omitempty"`
+	Resources       *corev1.ResourceRequirements `json:"resources,omitempty"`
 }
 
 // RedisStorage defines the structure used to store the Redis Data

--- a/api/redisfailover/v1/zz_generated.deepcopy.go
+++ b/api/redisfailover/v1/zz_generated.deepcopy.go
@@ -138,6 +138,11 @@ func (in *RedisExporter) DeepCopyInto(out *RedisExporter) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.Resources != nil {
+		in, out := &in.Resources, &out.Resources
+		*out = new(corev1.ResourceRequirements)
+		(*in).DeepCopyInto(*out)
+	}
 	return
 }
 
@@ -357,6 +362,11 @@ func (in *SentinelExporter) DeepCopyInto(out *SentinelExporter) {
 		for i := range *in {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
+	}
+	if in.Resources != nil {
+		in, out := &in.Resources, &out.Resources
+		*out = new(corev1.ResourceRequirements)
+		(*in).DeepCopyInto(*out)
 	}
 	return
 }

--- a/manifests/databases.spotahome.com_redisfailovers.yaml
+++ b/manifests/databases.spotahome.com_redisfailovers.yaml
@@ -1092,6 +1092,34 @@ spec:
                         description: PullPolicy describes a policy for if/when to
                           pull a container image
                         type: string
+                      resources:
+                        description: ResourceRequirements describes the compute resource
+                          requirements.
+                        properties:
+                          limits:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: 'Limits describes the maximum amount of compute
+                              resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                            type: object
+                          requests:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: 'Requests describes the minimum amount of
+                              compute resources required. If Requests is omitted for
+                              a container, it defaults to Limits if that is explicitly
+                              specified, otherwise to an implementation-defined value.
+                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                            type: object
+                        type: object
                     type: object
                   hostNetwork:
                     type: boolean
@@ -2695,6 +2723,34 @@ spec:
                         description: PullPolicy describes a policy for if/when to
                           pull a container image
                         type: string
+                      resources:
+                        description: ResourceRequirements describes the compute resource
+                          requirements.
+                        properties:
+                          limits:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: 'Limits describes the maximum amount of compute
+                              resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                            type: object
+                          requests:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: 'Requests describes the minimum amount of
+                              compute resources required. If Requests is omitted for
+                              a container, it defaults to Limits if that is explicitly
+                              specified, otherwise to an implementation-defined value.
+                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                            type: object
+                        type: object
                     type: object
                   hostNetwork:
                     type: boolean

--- a/operator/redisfailover/service/generator.go
+++ b/operator/redisfailover/service/generator.go
@@ -546,7 +546,22 @@ func generatePodDisruptionBudget(name string, namespace string, labels map[strin
 	}
 }
 
+var exporterDefaultResourceRequirements = corev1.ResourceRequirements{
+	Limits: corev1.ResourceList{
+		corev1.ResourceCPU:    resource.MustParse(exporterDefaultLimitCPU),
+		corev1.ResourceMemory: resource.MustParse(exporterDefaultLimitMemory),
+	},
+	Requests: corev1.ResourceList{
+		corev1.ResourceCPU:    resource.MustParse(exporterDefaultRequestCPU),
+		corev1.ResourceMemory: resource.MustParse(exporterDefaultRequestMemory),
+	},
+}
+
 func createRedisExporterContainer(rf *redisfailoverv1.RedisFailover) corev1.Container {
+	resources := exporterDefaultResourceRequirements
+	if rf.Spec.Redis.Exporter.Resources != nil {
+		resources = *rf.Spec.Redis.Exporter.Resources
+	}
 	container := corev1.Container{
 		Name:            exporterContainerName,
 		Image:           rf.Spec.Redis.Exporter.Image,
@@ -568,16 +583,7 @@ func createRedisExporterContainer(rf *redisfailoverv1.RedisFailover) corev1.Cont
 				Protocol:      corev1.ProtocolTCP,
 			},
 		},
-		Resources: corev1.ResourceRequirements{
-			Limits: corev1.ResourceList{
-				corev1.ResourceCPU:    resource.MustParse(exporterDefaultLimitCPU),
-				corev1.ResourceMemory: resource.MustParse(exporterDefaultLimitMemory),
-			},
-			Requests: corev1.ResourceList{
-				corev1.ResourceCPU:    resource.MustParse(exporterDefaultRequestCPU),
-				corev1.ResourceMemory: resource.MustParse(exporterDefaultRequestMemory),
-			},
-		},
+		Resources: resources,
 	}
 
 	if rf.Spec.Auth.SecretPath != "" {
@@ -599,6 +605,10 @@ func createRedisExporterContainer(rf *redisfailoverv1.RedisFailover) corev1.Cont
 }
 
 func createSentinelExporterContainer(rf *redisfailoverv1.RedisFailover) corev1.Container {
+	resources := exporterDefaultResourceRequirements
+	if rf.Spec.Sentinel.Exporter.Resources != nil {
+		resources = *rf.Spec.Sentinel.Exporter.Resources
+	}
 	container := corev1.Container{
 		Name:            sentinelExporterContainerName,
 		Image:           rf.Spec.Sentinel.Exporter.Image,
@@ -612,16 +622,7 @@ func createSentinelExporterContainer(rf *redisfailoverv1.RedisFailover) corev1.C
 				Protocol:      corev1.ProtocolTCP,
 			},
 		},
-		Resources: corev1.ResourceRequirements{
-			Limits: corev1.ResourceList{
-				corev1.ResourceCPU:    resource.MustParse(exporterDefaultLimitCPU),
-				corev1.ResourceMemory: resource.MustParse(exporterDefaultLimitMemory),
-			},
-			Requests: corev1.ResourceList{
-				corev1.ResourceCPU:    resource.MustParse(exporterDefaultRequestCPU),
-				corev1.ResourceMemory: resource.MustParse(exporterDefaultRequestMemory),
-			},
-		},
+		Resources: resources,
 	}
 	return container
 }


### PR DESCRIPTION
Fixes #266.

Changes proposed on the PR:
- Allow configuring the exporter CPU/memory requirements in the resource definition.

Comments:
I think I've got the basic logical change ready, but I've never worked on an operator before so I've got no clue about appropriate testing or documentation practices. Are the existing generator tests in combination with typechecking sufficient, or should there be some additional validation of the input when parsing / output during tests? (I don't see `Spec.Redis.Resources` being explicitly validated anywhere either, for example.)