### PR TITLE
Changed image tag in 'all-redis-operator-resources.yaml' 

### DIFF
--- a/example/operator/all-redis-operator-resources.yaml
+++ b/example/operator/all-redis-operator-resources.yaml
@@ -18,7 +18,7 @@ spec:
     spec:
       serviceAccountName: redisoperator
       containers:
-        - image: quay.io/spotahome/redis-operator:latest
+        - image: quay.io/spotahome/redis-operator:v1.0.0
           imagePullPolicy: IfNotPresent
           name: app
           securityContext:


### PR DESCRIPTION
Fixes #360.

The `quay.io/spotahome/redis-operator` image tagged as `latest` currently does not work when using the `kubectl` approach with raw yaml configs that are [linked in the Readme](https://github.com/MaxTaggart/redis-operator#using-kubectl). This PR changes the tag on the `quay.io/spotahome/redis-operator` image to `v1.0.0`, which does work. This tag can presumable be updated to `v1.1.0` when that version is stable.