### PR TITLE
Fixed variable comparisons in shutdown.sh and ready.sh

### DIFF
--- a/operator/redisfailover/service/generator.go
+++ b/operator/redisfailover/service/generator.go
@@ -165,7 +165,7 @@ func generateRedisShutdownConfigMap(rf *redisfailoverv1.RedisFailover, labels ma
 	labels = util.MergeLabels(labels, generateSelectorLabels(redisRoleName, rf.Name))
 	shutdownContent := `master=$(redis-cli -h ${RFS_REDIS_SERVICE_HOST} -p ${RFS_REDIS_SERVICE_PORT_SENTINEL} --csv SENTINEL get-master-addr-by-name mymaster | tr ',' ' ' | tr -d '\"' |cut -d' ' -f1)
 redis-cli SAVE
-if [[ $master ==  $(hostname -i) ]]; then
+if [ "$master" = "$(hostname -i)" ]; then
   redis-cli -h ${RFS_REDIS_SERVICE_HOST} -p ${RFS_REDIS_SERVICE_PORT_SENTINEL} SENTINEL failover mymaster
 fi`
 
@@ -193,7 +193,7 @@ func generateRedisReadinessConfigMap(rf *redisfailoverv1.RedisFailover, labels m
    NO_MASTER="master_host:127.0.0.1"
 
    cmd="redis-cli"
-   if [[ ! -z "${REDIS_PASSWORD}" ]]; then
+   if [ ! -z "${REDIS_PASSWORD}" ]; then
         cmd="${cmd} --no-auth-warning -a \"${REDIS_PASSWORD}\""
    fi
 
@@ -204,8 +204,8 @@ func generateRedisReadinessConfigMap(rf *redisfailoverv1.RedisFailover, labels m
    }
 
    check_slave(){
-           in_sync=$(echo "${cmd} | grep ${IN_SYNC} | tr -d \"\\r\" | tr -d \"\\n\"" | xargs -0 sh -c)  
-           no_master=$(echo "${cmd} | grep ${NO_MASTER} | tr -d \"\\r\" | tr -d \"\\n\"" |  xargs -0 sh -c) 
+           in_sync=$(echo "${cmd} | grep ${IN_SYNC} | tr -d \"\\r\" | tr -d \"\\n\"" | xargs -0 sh -c)
+           no_master=$(echo "${cmd} | grep ${NO_MASTER} | tr -d \"\\r\" | tr -d \"\\n\"" |  xargs -0 sh -c)
 
            if [ -z "$in_sync" ] && [ -z "$no_master" ]; then
                    exit 0


### PR DESCRIPTION
Fixes #363 .

Changes proposed on the PR:
- You are using /bin/sh to run shutdown.sh and ready.sh, but sh in Debian containers don't understand "==" and "[[ ]]" operands. 
