### PR TITLE
shutdown script environment variable fix

### DIFF
--- a/example/redisfailover/custom-shutdown.yaml
+++ b/example/redisfailover/custom-shutdown.yaml
@@ -17,8 +17,8 @@ metadata:
 data:
   shutdown.sh: |
     echo "shutdown in progress..."
-    master=$(redis-cli -h ${RFS_REDIS_SERVICE_HOST} -p ${RFS_REDIS_SERVICE_PORT_SENTINEL} --csv SENTINEL get-master-addr-by-name mymaster | tr ',' ' ' | tr -d '\"' |cut -d' ' -f1)
+    master=$(redis-cli -h ${RFS_REDISFAILOVER_SERVICE_HOST} -p ${RFS_REDISFAILOVER_SERVICE_PORT_SENTINEL} --csv SENTINEL get-master-addr-by-name mymaster | tr ',' ' ' | tr -d '\"' |cut -d' ' -f1)
     redis-cli SAVE
     if [[ $master ==  $(hostname -i) ]]; then
-      redis-cli -h ${RFS_REDIS_SERVICE_HOST} -p ${RFS_REDIS_SERVICE_PORT_SENTINEL} SENTINEL failover mymaster
+      redis-cli -h ${RFS_REDISFAILOVER_SERVICE_HOST} -p ${RFS_REDISFAILOVER_SERVICE_PORT_SENTINEL} SENTINEL failover mymaster
     fi


### PR DESCRIPTION
Changes proposed on the PR:
- makes the env variables of the shutdown script correct according to what's inside the container
- I checked what variables are inside the redis containers with `printenv` and didn't find any variable with `RFS_REDIS_*` but found instead of REDIS the failover name with capital letters
- something else I found that all variables belong to other failovers are inside the container for some reason.