### PR TITLE
Replace `-` with `_` like k8s does during shutdown script generation

### DIFF
--- a/operator/redisfailover/service/generator.go
+++ b/operator/redisfailover/service/generator.go
@@ -162,7 +162,7 @@ func generateRedisConfigMap(rf *redisfailoverv1.RedisFailover, labels map[string
 func generateRedisShutdownConfigMap(rf *redisfailoverv1.RedisFailover, labels map[string]string, ownerRefs []metav1.OwnerReference) *corev1.ConfigMap {
 	name := GetRedisShutdownConfigMapName(rf)
 	namespace := rf.Namespace
-	rfName := strings.ToUpper(rf.Name)
+	rfName := strings.Replace(strings.ToUpper(rf.Name), "-", "_", -1)
 
 	labels = util.MergeLabels(labels, generateSelectorLabels(redisRoleName, rf.Name))
 	shutdownContent := fmt.Sprintf(`master=$(redis-cli -h ${RFS_%[1]v_SERVICE_HOST} -p ${RFS_%[1]v_SERVICE_PORT_SENTINEL} --csv SENTINEL get-master-addr-by-name mymaster | tr ',' ' ' | tr -d '\"' |cut -d' ' -f1)


### PR DESCRIPTION
Signed-off-by: Jorge Turrado <jorge.turrado@docplanner.com>

Right now, the generated environment variables generated for shutdown script uses current redisfailover name, but if that name contains `-`, the env looks like `RFS_ONE-CACHE_SERVICE_HOST`. This makes the script useless because that service doesn't exists.

This PR replaces `-` with `_` like k8s does for solving this problem