### PR TITLE
CORE-3196: Increase redis-operator cpu requests and limits

### DIFF
--- a/charts/redisoperator/values.yaml
+++ b/charts/redisoperator/values.yaml
@@ -52,10 +52,10 @@ securityContext:
 # @default -- No requests or limits.
 resources:
   requests:
-    cpu: 100m
+    cpu: 500m
     memory: 128Mi
   limits:
-    cpu: 100m
+    cpu: 1000m
     memory: 128Mi
 
 ### Monitoring


### PR DESCRIPTION
Current values
![image](https://user-images.githubusercontent.com/665127/167373345-af200969-4a2a-46b6-a5b6-b8ecc49f3456.png)


The current values are 200 requests - 400 limits, it looks like it was manually deployed