### PR TITLE
Updated default redis version to 6.2.7

### DIFF
--- a/api/redisfailover/v1/defaults.go
+++ b/api/redisfailover/v1/defaults.go
@@ -5,7 +5,7 @@ const (
 	defaultSentinelNumber        = 3
 	defaultSentinelExporterImage = "quay.io/oliver006/redis_exporter:v1.33.0-alpine"
 	defaultExporterImage         = "quay.io/oliver006/redis_exporter:v1.33.0-alpine"
-	defaultImage                 = "redis:6.2.6-alpine"
+	defaultImage                 = "redis:6.2.7-alpine"
 	defaultRedisPort             = "6379"
 )
 


### PR DESCRIPTION
Since there's a [new patch version](https://github.com/redis/redis/releases/tag/6.2.7) with some security patches I think that it is good to have that as default.

Fixes N/A

Changes proposed on the PR:
- Update default redis version to 6.2.7