### PR TITLE
Update exporter image versions

### DIFF
--- a/api/redisfailover/v1/defaults.go
+++ b/api/redisfailover/v1/defaults.go
@@ -3,8 +3,8 @@ package v1
 const (
 	defaultRedisNumber           = 3
 	defaultSentinelNumber        = 3
-	defaultSentinelExporterImage = "quay.io/oliver006/redis_exporter:v1.33.0-alpine"
-	defaultExporterImage         = "quay.io/oliver006/redis_exporter:v1.33.0-alpine"
+	defaultSentinelExporterImage = "quay.io/oliver006/redis_exporter:v1.43.0"
+	defaultExporterImage         = "quay.io/oliver006/redis_exporter:v1.43.0"
 	defaultImage                 = "redis:6.2.6-alpine"
 	defaultRedisPort             = "6379"
 )


### PR DESCRIPTION
Image version upgrade

Changes proposed on the PR:
- The older images will not work on the ARM based instances.
