### PR TITLE
update default image

### DIFF
--- a/api/redisfailover/v1/defaults.go
+++ b/api/redisfailover/v1/defaults.go
@@ -5,7 +5,7 @@ const (
 	defaultSentinelNumber        = 3
 	defaultSentinelExporterImage = "quay.io/oliver006/redis_exporter:v1.33.0-alpine"
 	defaultExporterImage         = "quay.io/oliver006/redis_exporter:v1.33.0-alpine"
-	defaultImage                 = "redis:6.2.6-alpine"
+	defaultImage                 = "redis:6.2.7"
 	defaultRedisPort             = "6379"
 )
 


### PR DESCRIPTION
The alpha version looks like it can be replaced with the latest official version

Fixes # .

Changes proposed on the PR:
- change default redis image