### PR TITLE
Security context merge

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.17
 
 require (
 	github.com/go-redis/redis/v8 v8.11.5
+	github.com/imdario/mergo v0.3.12
 	github.com/prometheus/client_golang v1.13.0
 	github.com/sirupsen/logrus v1.9.0
 	github.com/spotahome/kooper/v2 v2.2.0
@@ -34,7 +35,6 @@ require (
 	github.com/google/go-cmp v0.5.8 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/google/uuid v1.3.0 // indirect
-	github.com/imdario/mergo v0.3.12 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/mailru/easyjson v0.7.6 // indirect

--- a/operator/redisfailover/service/generator.go
+++ b/operator/redisfailover/service/generator.go
@@ -704,10 +704,6 @@ func getAffinity(affinity *corev1.Affinity, labels map[string]string) *corev1.Af
 }
 
 func getSecurityContext(secctx *corev1.PodSecurityContext) *corev1.PodSecurityContext {
-	if secctx != nil {
-		return secctx
-	}
-
 	defaultUserAndGroup := int64(1000)
 	runAsNonRoot := true
 

--- a/operator/redisfailover/service/generator.go
+++ b/operator/redisfailover/service/generator.go
@@ -13,6 +13,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
+	"github.com/imdario/mergo"
 	redisfailoverv1 "github.com/spotahome/redis-operator/api/redisfailover/v1"
 	"github.com/spotahome/redis-operator/operator/redisfailover/util"
 )
@@ -710,12 +711,18 @@ func getSecurityContext(secctx *corev1.PodSecurityContext) *corev1.PodSecurityCo
 	defaultUserAndGroup := int64(1000)
 	runAsNonRoot := true
 
-	return &corev1.PodSecurityContext{
+	psc := corev1.PodSecurityContext{
 		RunAsUser:    &defaultUserAndGroup,
 		RunAsGroup:   &defaultUserAndGroup,
 		RunAsNonRoot: &runAsNonRoot,
 		FSGroup:      &defaultUserAndGroup,
 	}
+
+	if secctx != nil {
+		mergo.Merge(&psc, secctx)
+	}
+
+	return &psc
 }
 
 func getContainerSecurityContext(secctx *corev1.SecurityContext) *corev1.SecurityContext {

--- a/operator/redisfailover/service/generator.go
+++ b/operator/redisfailover/service/generator.go
@@ -715,7 +715,7 @@ func getSecurityContext(secctx *corev1.PodSecurityContext) *corev1.PodSecurityCo
 	}
 
 	if secctx != nil {
-		mergo.Merge(&psc, secctx)
+		mergo.Merge(&psc, secctx, mergo.WithOverride)
 	}
 
 	return &psc


### PR DESCRIPTION
Fixes #469  .

> **NOTE:** On the contrary might not be good idea to do this is the dest and src securityContext's have conflicting parameters.

@ese what do you think? I am ok either ways.