### PR TITLE
Redis env to extracontainers

### DIFF
--- a/example/redisfailover/sidecars.yaml
+++ b/example/redisfailover/sidecars.yaml
@@ -4,12 +4,23 @@ kind: Namespace
 metadata:
   name: sc
 ---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: redis-auth
+  namespace: sc
+type: Opaque
+stringData:
+  password: pass
+---
 apiVersion: databases.spotahome.com/v1
 kind: RedisFailover
 metadata:
   name: sidecars
   namespace: sc
 spec:
+  auth:
+    secretPath: redis-auth
   sentinel:
     initContainers:
     - name: echo

--- a/operator/redisfailover/service/generator.go
+++ b/operator/redisfailover/service/generator.go
@@ -958,6 +958,17 @@ func getContainersWithRedisEnv(cs []corev1.Container, e []corev1.EnvVar) []corev
 
 func getRedisEnv(rf *redisfailoverv1.RedisFailover) []corev1.EnvVar {
 	var env []corev1.EnvVar
+
+	env = append(env, corev1.EnvVar{
+		Name:  "REDIS_ADDR",
+		Value: fmt.Sprintf("redis://localhost:%[1]v", rf.Spec.Redis.Port),
+	})
+
+	env = append(env, corev1.EnvVar{
+		Name:  "REDIS_PORT",
+		Value: fmt.Sprintf("%[1]v", rf.Spec.Redis.Port),
+	})
+
 	env = append(env, corev1.EnvVar{
 		Name:  "REDIS_USERNAME",
 		Value: "default",
@@ -976,16 +987,6 @@ func getRedisEnv(rf *redisfailoverv1.RedisFailover) []corev1.EnvVar {
 			},
 		})
 	}
-
-	env = append(env, corev1.EnvVar{
-		Name:  "REDIS_ADDR",
-		Value: fmt.Sprintf("redis://localhost:%[1]v", rf.Spec.Redis.Port),
-	})
-
-	env = append(env, corev1.EnvVar{
-		Name:  "REDIS_PORT",
-		Value: fmt.Sprintf("%[1]v", rf.Spec.Redis.Port),
-	})
 
 	return env
 }

--- a/operator/redisfailover/service/generator.go
+++ b/operator/redisfailover/service/generator.go
@@ -970,7 +970,7 @@ func getRedisEnv(rf *redisfailoverv1.RedisFailover) []corev1.EnvVar {
 	})
 
 	env = append(env, corev1.EnvVar{
-		Name:  "REDIS_USERNAME",
+		Name:  "REDIS_USER",
 		Value: "default",
 	})
 

--- a/test/integration/redisfailover/creation_test.go
+++ b/test/integration/redisfailover/creation_test.go
@@ -268,7 +268,7 @@ func (c *clients) testAuth(t *testing.T) {
 	assert.Equal(redisSS.Spec.Template.Spec.Containers[1].Env[1].Value, redisAddr)
 	assert.Equal(redisSS.Spec.Template.Spec.Containers[1].Env[2].Name, "REDIS_PORT")
 	assert.Equal(redisSS.Spec.Template.Spec.Containers[1].Env[2].Value, "6379")
-	assert.Equal(redisSS.Spec.Template.Spec.Containers[1].Env[3].Name, "REDIS_USERNAME")
+	assert.Equal(redisSS.Spec.Template.Spec.Containers[1].Env[3].Name, "REDIS_USER")
 	assert.Equal(redisSS.Spec.Template.Spec.Containers[1].Env[3].Value, "default")
 	assert.Equal(redisSS.Spec.Template.Spec.Containers[1].Env[4].Name, "REDIS_PASSWORD")
 	assert.Equal(redisSS.Spec.Template.Spec.Containers[1].Env[4].ValueFrom.SecretKeyRef.Key, "password")

--- a/test/integration/redisfailover/creation_test.go
+++ b/test/integration/redisfailover/creation_test.go
@@ -39,6 +39,7 @@ const (
 	sentinelSize   = int32(3)
 	authSecretPath = "redis-auth"
 	testPass       = "test-pass"
+	redisAddr      = "redis://localhost:6379"
 )
 
 type clients struct {
@@ -260,10 +261,17 @@ func (c *clients) testAuth(t *testing.T) {
 	assert.Contains(redisCfg.Data["redis.conf"], "masterauth "+testPass)
 
 	redisSS, err := c.k8sClient.AppsV1().StatefulSets(namespace).Get(context.Background(), fmt.Sprintf("rfr-%s", name), metav1.GetOptions{})
+	redis_addr := fmt.Sprintf("redis://localhost:%[1]v")
 	assert.NoError(err)
 
 	assert.Len(redisSS.Spec.Template.Spec.Containers, 2)
-	assert.Equal(redisSS.Spec.Template.Spec.Containers[1].Env[1].Name, "REDIS_PASSWORD")
-	assert.Equal(redisSS.Spec.Template.Spec.Containers[1].Env[1].ValueFrom.SecretKeyRef.Key, "password")
-	assert.Equal(redisSS.Spec.Template.Spec.Containers[1].Env[1].ValueFrom.SecretKeyRef.LocalObjectReference.Name, authSecretPath)
+	assert.Equal(redisSS.Spec.Template.Spec.Containers[1].Env[1].Name, "REDIS_ADDR")
+	assert.Equal(redisSS.Spec.Template.Spec.Containers[1].Env[1].Value, redisAddr)
+	assert.Equal(redisSS.Spec.Template.Spec.Containers[1].Env[2].Name, "REDIS_PORT")
+	assert.Equal(redisSS.Spec.Template.Spec.Containers[1].Env[2].Value, "6379")
+	assert.Equal(redisSS.Spec.Template.Spec.Containers[1].Env[3].Name, "REDIS_USERNAME")
+	assert.Equal(redisSS.Spec.Template.Spec.Containers[1].Env[3].Value, "default")
+	assert.Equal(redisSS.Spec.Template.Spec.Containers[1].Env[4].Name, "REDIS_PASSWORD")
+	assert.Equal(redisSS.Spec.Template.Spec.Containers[1].Env[4].ValueFrom.SecretKeyRef.Key, "password")
+	assert.Equal(redisSS.Spec.Template.Spec.Containers[1].Env[4].ValueFrom.SecretKeyRef.LocalObjectReference.Name, authSecretPath)
 }

--- a/test/integration/redisfailover/creation_test.go
+++ b/test/integration/redisfailover/creation_test.go
@@ -261,7 +261,6 @@ func (c *clients) testAuth(t *testing.T) {
 	assert.Contains(redisCfg.Data["redis.conf"], "masterauth "+testPass)
 
 	redisSS, err := c.k8sClient.AppsV1().StatefulSets(namespace).Get(context.Background(), fmt.Sprintf("rfr-%s", name), metav1.GetOptions{})
-	redis_addr := fmt.Sprintf("redis://localhost:%[1]v")
 	assert.NoError(err)
 
 	assert.Len(redisSS.Spec.Template.Spec.Containers, 2)


### PR DESCRIPTION
Fixes #000 .

Changes proposed on the PR:
- Passes the following env to all extraContainers and initContainers
```
- REDIS_USER
- REDIS_PASSWORD
- REDIS_ADDR
- REDIS_PORT
```