### PR TITLE
Configuration to accept empty lines

### DIFF
--- a/service/redis/client.go
+++ b/service/redis/client.go
@@ -305,6 +305,10 @@ func (c *client) SetCustomRedisConfig(ip string, port string, configs []string, 
 		if err != nil {
 			return err
 		}
+		// If the configuration is an empty line , it will result in an incorrect configSet, which will not run properly down the line.
+		if strings.TrimSpace(param) == "" || strings.TrimSpace(value) == "" {
+			continue
+		}
 		if err := c.applyRedisConfig(param, value, rClient); err != nil {
 			return err
 		}


### PR DESCRIPTION
Most scenarios do not produce an empty configuration line. However, there are some cases where empty lines can be generated. operator will keep trying to configure empty lines, which is an invalid operation. operator is fully capable of avoiding this scenario.

Fixes # .

Changes proposed on the PR:
- 
- 
- 