### PR TITLE
Update client.go

### DIFF
--- a/operator/redisfailover/service/client.go
+++ b/operator/redisfailover/service/client.go
@@ -146,8 +146,11 @@ func (r *RedisFailoverKubeClient) ensurePodDisruptionBudget(rf *redisfailoverv1.
 	namespace := rf.Namespace
 
 	minAvailable := intstr.FromInt(2)
-	if rf.Spec.Redis.Replicas <= 2 {
-		minAvailable = intstr.FromInt(int(rf.Spec.Redis.Replicas - 1))
+	if rf.Spec.Redis.Replicas == 2 {
+		minAvailable = intstr.FromInt(1)
+	} else if rf.Spec.Redis.Replicas <= 1 {
+		// No need to create this resource
+		return nil
 	}
 
 	labels = util.MergeLabels(labels, generateSelectorLabels(component, rf.Name))

--- a/operator/redisfailover/service/client.go
+++ b/operator/redisfailover/service/client.go
@@ -146,11 +146,8 @@ func (r *RedisFailoverKubeClient) ensurePodDisruptionBudget(rf *redisfailoverv1.
 	namespace := rf.Namespace
 
 	minAvailable := intstr.FromInt(2)
-	if rf.Spec.Redis.Replicas == 2 {
+	if rf.Spec.Redis.Replicas <= 2 {
 		minAvailable = intstr.FromInt(1)
-	} else if rf.Spec.Redis.Replicas <= 1 {
-		// No need to create this resource
-		return nil
 	}
 
 	labels = util.MergeLabels(labels, generateSelectorLabels(component, rf.Name))


### PR DESCRIPTION
When replica is 1 or zero, this resource can be created without. There is no point in creating it.
When replica is 0, the original logic creates a resource with min -1. This is something that K8s would reject if it could actually be committed.

Fixes # .

Changes proposed on the PR:
- 
- 
- 