### PR TITLE
Deployment extensions/v1beta1 deprecated since 1.16, not 1.19

### DIFF
--- a/charts/redisoperator/Chart.yaml
+++ b/charts/redisoperator/Chart.yaml
@@ -12,3 +12,4 @@ keywords:
   - "cluster"
 sources:
   - https://github.com/spotahome/redis-operator
+kubeVersion: '>=1.21.0-0'

--- a/charts/redisoperator/templates/_versions.tpl
+++ b/charts/redisoperator/templates/_versions.tpl
@@ -3,13 +3,7 @@
 Return the appropriate apiVersion for deployment.
 */}}
 {{- define "common.capabilities.deployment.apiVersion" -}}
-{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
 {{- print "apps/v1" -}}
-{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
-{{- print "extensions/v1beta1" -}}
-{{- else -}}
-{{- print "apps/v1" -}}
-{{- end -}}
 {{- end -}}
 
 {{/*


### PR DESCRIPTION
Fixes https://github.com/spotahome/redis-operator/issues/486

Changes proposed on the PR:



per https://kubernetes.io/docs/reference/using-api/deprecation-guide/

The extensions/v1beta1, apps/v1beta1, and apps/v1beta2 API versions of Deployment are no longer served as of v1.16.

So this operator is not working under k8s 1.18