### PR TITLE
feat(helm): add replicas option in chart

### DIFF
--- a/charts/redisoperator/templates/deployment.yaml
+++ b/charts/redisoperator/templates/deployment.yaml
@@ -12,7 +12,7 @@ metadata:
 {{ toYaml .Values.annotations | indent 4 }}
   {{- end }}
 spec:
-  replicas: 1
+  replicas: {{ .Values.replicas }}
   selector:
     matchLabels:
       {{- include "chart.selectorLabels" $data | nindent 6 }}

--- a/charts/redisoperator/values.yaml
+++ b/charts/redisoperator/values.yaml
@@ -21,6 +21,8 @@ imageCredentials:
 updateStrategy:
   type: RollingUpdate
 
+replicas: 1
+
 # A name in place of the chart name for `app:` labels.
 nameOverride: ""
 


### PR DESCRIPTION
With the recent introduction of the leader election in the Operator, we're now able to deploy multiple pods through the Helm chart.