### PR TITLE
[feature]add rf Annotations to sts

### DIFF
--- a/operator/redisfailover/service/generator.go
+++ b/operator/redisfailover/service/generator.go
@@ -280,6 +280,7 @@ func generateRedisStatefulSet(rf *redisfailoverv1.RedisFailover, labels map[stri
 
 	ss := &appsv1.StatefulSet{
 		ObjectMeta: metav1.ObjectMeta{
+			Annotations:     rf.Annotations,
 			Name:            name,
 			Namespace:       namespace,
 			Labels:          labels,

--- a/operator/redisfailover/util/label.go
+++ b/operator/redisfailover/util/label.go
@@ -11,3 +11,15 @@ func MergeLabels(allLabels ...map[string]string) map[string]string {
 	}
 	return res
 }
+
+// MergeAnnotations merges all the annotations maps received as argument into a single new label map.
+func MergeAnnotations(allMergeAnnotations ...map[string]string) map[string]string {
+	res := map[string]string{}
+
+	for _, labels := range allMergeAnnotations {
+		for k, v := range labels {
+			res[k] = v
+		}
+	}
+	return res
+}

--- a/service/k8s/statefulset.go
+++ b/service/k8s/statefulset.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/spotahome/redis-operator/operator/redisfailover/util"
+
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -99,6 +101,7 @@ func (s *StatefulSetService) CreateOrUpdateStatefulSet(namespace string, statefu
 	// namespace is our spec(https://github.com/kubernetes/community/blob/master/contributors/devel/api-conventions.md#concurrency-control-and-consistency),
 	// we will replace the current namespace state.
 	statefulSet.ResourceVersion = storedStatefulSet.ResourceVersion
+	statefulSet.Annotations = util.MergeLabels(statefulSet.Annotations, storedStatefulSet.Annotations)
 	return s.UpdateStatefulSet(namespace, statefulSet)
 }
 

--- a/service/k8s/statefulset.go
+++ b/service/k8s/statefulset.go
@@ -101,7 +101,7 @@ func (s *StatefulSetService) CreateOrUpdateStatefulSet(namespace string, statefu
 	// namespace is our spec(https://github.com/kubernetes/community/blob/master/contributors/devel/api-conventions.md#concurrency-control-and-consistency),
 	// we will replace the current namespace state.
 	statefulSet.ResourceVersion = storedStatefulSet.ResourceVersion
-	statefulSet.Annotations = util.MergeLabels(statefulSet.Annotations, storedStatefulSet.Annotations)
+	statefulSet.Annotations = util.MergeAnnotations(statefulSet.Annotations, storedStatefulSet.Annotations)
 	return s.UpdateStatefulSet(namespace, statefulSet)
 }
 

--- a/service/redis/client.go
+++ b/service/redis/client.go
@@ -306,7 +306,8 @@ func (c *client) SetCustomRedisConfig(ip string, port string, configs []string, 
 			return err
 		}
 		// If the configuration is an empty line , it will result in an incorrect configSet, which will not run properly down the line.
-		if strings.TrimSpace(param) == "" || strings.TrimSpace(value) == "" {
+		// `config set save ""` should support
+		if strings.TrimSpace(param) == "" {
 			continue
 		}
 		if err := c.applyRedisConfig(param, value, rClient); err != nil {


### PR DESCRIPTION
Fixes # .
The annotations for CR resources are usually carried over to the main working resources. This is because sometimes other operator operations need to recognise specific annotations. redis-operator now has no such entry point to inject specific annotations.
Changes proposed on the PR:
- Provide an entry point to inject annotations into work resources。
- 
- 