### PR TITLE
Parameterize concurrency (number of workers). Users should be able to…

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -16,6 +16,7 @@ type CMDFlags struct {
 	Debug       bool
 	ListenAddr  string
 	MetricsPath string
+	Concurrency int
 }
 
 // Init initializes and parse the flags
@@ -27,7 +28,7 @@ func (c *CMDFlags) Init() {
 	flag.BoolVar(&c.Debug, "debug", false, "enable debug mode")
 	flag.StringVar(&c.ListenAddr, "listen-address", ":9710", "Address to listen on for metrics.")
 	flag.StringVar(&c.MetricsPath, "metrics-path", "/metrics", "Path to serve the metrics.")
-
+	flag.IntVar(&c.Concurrency, "concurrency", 3, "Number of conccurent workers meant to process events")
 	// Parse flags
 	flag.Parse()
 }
@@ -37,5 +38,6 @@ func (c *CMDFlags) ToRedisOperatorConfig() redisfailover.Config {
 	return redisfailover.Config{
 		ListenAddress: c.ListenAddr,
 		MetricsPath:   c.MetricsPath,
+		Concurrency:   c.Concurrency,
 	}
 }

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -28,6 +28,8 @@ func (c *CMDFlags) Init() {
 	flag.BoolVar(&c.Debug, "debug", false, "enable debug mode")
 	flag.StringVar(&c.ListenAddr, "listen-address", ":9710", "Address to listen on for metrics.")
 	flag.StringVar(&c.MetricsPath, "metrics-path", "/metrics", "Path to serve the metrics.")
+	// default is 3 for conccurency because kooper also defines 3 as default
+	// reference: https://github.com/spotahome/kooper/blob/master/controller/controller.go#L89
 	flag.IntVar(&c.Concurrency, "concurrency", 3, "Number of conccurent workers meant to process events")
 	// Parse flags
 	flag.Parse()

--- a/operator/redisfailover/config.go
+++ b/operator/redisfailover/config.go
@@ -4,4 +4,5 @@ package redisfailover
 type Config struct {
 	ListenAddress string
 	MetricsPath   string
+	Concurrency   int
 }

--- a/operator/redisfailover/factory.go
+++ b/operator/redisfailover/factory.go
@@ -47,13 +47,14 @@ func New(cfg Config, k8sService k8s.Services, k8sClient kubernetes.Interface, lo
 
 	// Create our controller.
 	return controller.New(&controller.Config{
-		Handler:         rfHandler,
-		Retriever:       rfRetriever,
-		LeaderElector:   leSVC,
-		MetricsRecorder: kooperMetricsRecorder,
-		Logger:          kooperLogger,
-		Name:            "redisfailover",
-		ResyncInterval:  resync,
+		Handler:           rfHandler,
+		Retriever:         rfRetriever,
+		LeaderElector:     leSVC,
+		MetricsRecorder:   kooperMetricsRecorder,
+		Logger:            kooperLogger,
+		Name:              "redisfailover",
+		ResyncInterval:    resync,
+		ConcurrentWorkers: cfg.Concurrency,
 	})
 }
 


### PR DESCRIPTION
Changes proposed on the PR:
* parameterize option for number of concurrent workers
this is required because if the number of CRs are pretty high, we see workerQueue getting piled up and sync events may even miss an entire cycle.

for example, when running around 100 CRs concurrently, we see that wait time in queue is consistently around 30-40s

![when number of workers are less](https://user-images.githubusercontent.com/113178711/197338628-a96533f4-49fc-4fca-b205-13ff47ffdb49.png)

