### PR TITLE
Always safer to use the loopback ip to reduce ambiguity

### DIFF
--- a/operator/redisfailover/service/generator.go
+++ b/operator/redisfailover/service/generator.go
@@ -647,7 +647,7 @@ func createSentinelExporterContainer(rf *redisfailoverv1.RedisFailover) corev1.C
 			Value: fmt.Sprintf("0.0.0.0:%[1]v", sentinelExporterPort),
 		}, corev1.EnvVar{
 			Name:  "REDIS_ADDR",
-			Value: "redis://localhost:26379",
+			Value: "redis://127.0.0.1:26379",
 		},
 		),
 		Ports: []corev1.ContainerPort{
@@ -961,7 +961,7 @@ func getRedisEnv(rf *redisfailoverv1.RedisFailover) []corev1.EnvVar {
 
 	env = append(env, corev1.EnvVar{
 		Name:  "REDIS_ADDR",
-		Value: fmt.Sprintf("redis://localhost:%[1]v", rf.Spec.Redis.Port),
+		Value: fmt.Sprintf("redis://127.0.0.1:%[1]v", rf.Spec.Redis.Port),
 	})
 
 	env = append(env, corev1.EnvVar{

--- a/test/integration/redisfailover/creation_test.go
+++ b/test/integration/redisfailover/creation_test.go
@@ -42,7 +42,7 @@ const (
 	sentinelSize   = int32(3)
 	authSecretPath = "redis-auth"
 	testPass       = "test-pass"
-	redisAddr      = "redis://localhost:6379"
+	redisAddr      = "redis://127.0.0.1:6379"
 )
 
 type clients struct {


### PR DESCRIPTION
It is always better to use the loopback IP instead of the `localhost`.