### PR TITLE
`startupConfig` to pass custom Startup Probes

### DIFF
--- a/api/redisfailover/v1/types.go
+++ b/api/redisfailover/v1/types.go
@@ -46,6 +46,7 @@ type RedisSettings struct {
 	CustomCommandRenames          []RedisCommandRename              `json:"customCommandRenames,omitempty"`
 	Command                       []string                          `json:"command,omitempty"`
 	ShutdownConfigMap             string                            `json:"shutdownConfigMap,omitempty"`
+	StartupConfigMap              string                            `json:"startupConfigMap,omitempty"`
 	Storage                       RedisStorage                      `json:"storage,omitempty"`
 	InitContainers                []corev1.Container                `json:"initContainers,omitempty"`
 	Exporter                      Exporter                          `json:"exporter,omitempty"`
@@ -76,6 +77,7 @@ type SentinelSettings struct {
 	Resources                 corev1.ResourceRequirements       `json:"resources,omitempty"`
 	CustomConfig              []string                          `json:"customConfig,omitempty"`
 	Command                   []string                          `json:"command,omitempty"`
+	StartupConfigMap          string                            `json:"startupConfigMap,omitempty"`
 	Affinity                  *corev1.Affinity                  `json:"affinity,omitempty"`
 	SecurityContext           *corev1.PodSecurityContext        `json:"securityContext,omitempty"`
 	ContainerSecurityContext  *corev1.SecurityContext           `json:"containerSecurityContext,omitempty"`

--- a/example/operator/custom-startup-config.yaml
+++ b/example/operator/custom-startup-config.yaml
@@ -1,0 +1,32 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: startup-config
+data:
+  startup.sh: |
+    #!/bin/bash
+    redis-cli -h 127.0.0.1 -p ${REDIS_PORT} ping --user pinger --pass pingpass --no-auth-warning
+---
+apiVersion: databases.spotahome.com/v1
+kind: RedisFailover
+metadata:
+  name: redisfailover
+spec:
+  sentinel:
+    replicas: 3
+    resources:
+      requests:
+        cpu: 100m
+      limits:
+        memory: 100Mi
+  redis:
+    replicas: 3
+    startupConfigMap: startup-config
+    resources:
+      requests:
+        cpu: 100m
+        memory: 200Mi
+      limits:
+        cpu: 400m
+        memory: 500Mi

--- a/manifests/databases.spotahome.com_redisfailovers.yaml
+++ b/manifests/databases.spotahome.com_redisfailovers.yaml
@@ -5785,6 +5785,8 @@ spec:
                     type: object
                   shutdownConfigMap:
                     type: string
+                  startupConfigMap:
+                    type: string
                   storage:
                     description: RedisStorage defines the structure used to store
                       the Redis Data
@@ -12205,6 +12207,8 @@ spec:
                     additionalProperties:
                       type: string
                     type: object
+                  startupConfigMap:
+                    type: string
                   tolerations:
                     items:
                       description: The pod this Toleration is attached to tolerates

--- a/manifests/kustomize/base/databases.spotahome.com_redisfailovers.yaml
+++ b/manifests/kustomize/base/databases.spotahome.com_redisfailovers.yaml
@@ -5785,6 +5785,8 @@ spec:
                     type: object
                   shutdownConfigMap:
                     type: string
+                  startupConfigMap:
+                    type: string
                   storage:
                     description: RedisStorage defines the structure used to store
                       the Redis Data
@@ -12205,6 +12207,8 @@ spec:
                     additionalProperties:
                       type: string
                     type: object
+                  startupConfigMap:
+                    type: string
                   tolerations:
                     items:
                       description: The pod this Toleration is attached to tolerates

--- a/operator/redisfailover/service/generator.go
+++ b/operator/redisfailover/service/generator.go
@@ -348,7 +348,7 @@ func generateRedisStatefulSet(rf *redisfailoverv1.RedisFailover, labels map[stri
 										Command: []string{
 											"sh",
 											"-c",
-											fmt.Sprintf("redis-cli -h 127.0.0.1 -p %[1]v ping --user pinger --pass pingpass --no-auth-warning", rf.Spec.Redis.Port),
+											fmt.Sprintf("redis-cli -h ${hostname} -p %[1]v ping --user pinger --pass pingpass --no-auth-warning", rf.Spec.Redis.Port),
 										},
 									},
 								},

--- a/operator/redisfailover/service/generator.go
+++ b/operator/redisfailover/service/generator.go
@@ -348,7 +348,7 @@ func generateRedisStatefulSet(rf *redisfailoverv1.RedisFailover, labels map[stri
 										Command: []string{
 											"sh",
 											"-c",
-											fmt.Sprintf("redis-cli -h ${hostname} -p %[1]v ping --user pinger --pass pingpass --no-auth-warning", rf.Spec.Redis.Port),
+											fmt.Sprintf("redis-cli -h $(hostname) -p %[1]v ping --user pinger --pass pingpass --no-auth-warning", rf.Spec.Redis.Port),
 										},
 									},
 								},


### PR DESCRIPTION
Changes proposed on the PR:
- Adds `startupConfig` for Redis
- Adds `startupConfig` for Sentinel
