### PR TITLE
Remove error log for get service.

### DIFF
--- a/service/k8s/service.go
+++ b/service/k8s/service.go
@@ -44,7 +44,6 @@ func (s *ServiceService) GetService(namespace string, name string) (*corev1.Serv
 	service, err := s.kubeClient.CoreV1().Services(namespace).Get(context.TODO(), name, metav1.GetOptions{})
 	recordMetrics(namespace, "Service", name, "GET", err, s.metricsRecorder)
 	if err != nil {
-		log.Errorf("Error while getting service %v in %v namespace : %v", name, namespace, err)
 		return nil, err
 	}
 	return service, err


### PR DESCRIPTION
if redis exporter is not enabled, it will try to remove redis service. while doing to, it will first check if the service is present, and then proceed to remove the service. if the service is not present, error is logged, eventhough it is not harmful.

Fixes #543 

Changes proposed on the PR:
- 
- 
- 