### PR TITLE
Fix sentinel health check

### DIFF
--- a/operator/redisfailover/service/check.go
+++ b/operator/redisfailover/service/check.go
@@ -483,7 +483,7 @@ func (r *RedisFailoverChecker) IsRedisRunning(rFailover *redisfailoverv1.RedisFa
 // IsSentinelRunning returns true if all the pods are Running
 func (r *RedisFailoverChecker) IsSentinelRunning(rFailover *redisfailoverv1.RedisFailover) bool {
 	dp, err := r.k8sService.GetDeploymentPods(rFailover.Namespace, GetSentinelName(rFailover))
-	return err == nil && len(dp.Items) > int(rFailover.Spec.Redis.Replicas-1) && AreAllRunning(dp)
+	return err == nil && len(dp.Items) > int(rFailover.Spec.Sentinel.Replicas-1) && AreAllRunning(dp)
 }
 
 // IsClusterRunning returns true if all the pods in the given redisfailover are Running

--- a/operator/redisfailover/service/generator.go
+++ b/operator/redisfailover/service/generator.go
@@ -250,7 +250,7 @@ case $role in
 				check_slave
 				;;
 		*)
-				echo "unespected"
+				echo "unexpected"
 				exit 1
 esac`, port)
 


### PR DESCRIPTION
Fixes the sentinel health check to actually count sentinel pods instead of redis pods. Otherwise a cluster with more redis than sentinel replicas will never become ready. Copy-paste error introduced in 1e46182984c0dee22b95382acd7eb3c1c7cac6d8

Also corrects a minor typo in the redis readiness check script.