### PR TITLE
fix: sentinel readiness probe to fail when monitoring localhost

### DIFF
--- a/operator/redisfailover/service/generator.go
+++ b/operator/redisfailover/service/generator.go
@@ -517,7 +517,7 @@ func generateSentinelDeployment(rf *redisfailoverv1.RedisFailover, labels map[st
 							},
 							VolumeMounts: volumeMounts,
 							Command:      sentinelCommand,
-              // Readiness Probe fails when sentinel is monitoring localhost as master
+              						// Readiness Probe fails when sentinel is monitoring localhost as master
 							ReadinessProbe: &corev1.Probe{
 								InitialDelaySeconds: graceTime,
 								TimeoutSeconds:      5,

--- a/operator/redisfailover/service/generator.go
+++ b/operator/redisfailover/service/generator.go
@@ -517,6 +517,7 @@ func generateSentinelDeployment(rf *redisfailoverv1.RedisFailover, labels map[st
 							},
 							VolumeMounts: volumeMounts,
 							Command:      sentinelCommand,
+              // Readiness Probe fails when sentinel is monitoring localhost as master
 							ReadinessProbe: &corev1.Probe{
 								InitialDelaySeconds: graceTime,
 								TimeoutSeconds:      5,
@@ -525,7 +526,7 @@ func generateSentinelDeployment(rf *redisfailoverv1.RedisFailover, labels map[st
 										Command: []string{
 											"sh",
 											"-c",
-											"redis-cli -h $(hostname) -p 26379 ping",
+											"redis-cli -h $(hostname) -p 26379 sentinel get-master-addr-by-name mymaster | head -n 1 | grep -vq '127.0.0.1'",
 										},
 									},
 								},


### PR DESCRIPTION
Fixes #532  .

Changes proposed on the PR:
-  Readiness check for sentinel shall fail when it doesn't monitor the right master, at least when we know that it monitors the wrong one which is 127.0.0.1
-  There'll be dependency on grep and head existing on the redis image used for sentinels. I tested alpine and bullseye in the official redis images [here](https://hub.docker.com/_/redis) and they worked as expected.

I think we should have customised readiness and liveness checks in the future as well but for now this should be enough.