### PR TITLE
Remove resource request and limit spec from values

### DIFF
--- a/charts/redisoperator/values.yaml
+++ b/charts/redisoperator/values.yaml
@@ -55,13 +55,13 @@ securityContext:
 # Container resource [requests and limits](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/).
 # See the [API reference](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#resources) for details.
 # @default -- No requests or limits.
-resources:
-  requests:
-    cpu: 100m
-    memory: 128Mi
-  limits:
-    cpu: 100m
-    memory: 128Mi
+resources: {}
+#   requests:
+#     cpu: 100m
+#     memory: 128Mi
+#   limits:
+#     cpu: 100m
+#     memory: 128Mi
 
 ### Monitoring
 ###############


### PR DESCRIPTION
This PR is for removing resource spec from the values.yaml file.
Also, since cpu limits cause throttling on the pod, it is advisable to only define a cpu request.
https://home.robusta.dev/blog/stop-using-cpu-limits

Changes proposed on the PR:
- Remove cpu limits from the resource spec

---
*PR sponsored by [Obmondo.com](https://obmondo.com)*