### PR TITLE
Ensure the we retain the environment of exporter

### DIFF
--- a/operator/redisfailover/service/generator.go
+++ b/operator/redisfailover/service/generator.go
@@ -639,7 +639,7 @@ func createRedisExporterContainer(rf *redisfailoverv1.RedisFailover) corev1.Cont
 		Resources: resources,
 	}
 
-	redisEnv := getRedisEnv(rf)
+	redisEnv := getRedisExporterEnv(rf)
 	container.Env = append(container.Env, redisEnv...)
 
 	return container
@@ -1060,4 +1060,51 @@ func getRedisEnv(rf *redisfailoverv1.RedisFailover) []corev1.EnvVar {
 	}
 
 	return env
+}
+
+func getRedisExporterEnv(rf *redisfailoverv1.RedisFailover) []corev1.EnvVar {
+	var env []corev1.EnvVar
+
+	env = append(env, corev1.EnvVar{
+		Name:  "REDIS_ADDR",
+		Value: fmt.Sprintf("redis://127.0.0.1:%[1]v", rf.Spec.Redis.Port),
+	})
+
+	env = append(env, corev1.EnvVar{
+		Name:  "REDIS_PORT",
+		Value: fmt.Sprintf("%[1]v", rf.Spec.Redis.Port),
+	})
+
+	if !envExists(rf.Spec.Redis.Exporter.Env, "REDIS_USER") {
+		env = append(env, corev1.EnvVar{
+			Name:  "REDIS_USER",
+			Value: "default",
+		})
+	}
+
+	if !envExists(rf.Spec.Redis.Exporter.Env, "REDIS_PASSWORD") {
+		if rf.Spec.Auth.SecretPath != "" {
+			env = append(env, corev1.EnvVar{
+				Name: "REDIS_PASSWORD",
+				ValueFrom: &corev1.EnvVarSource{
+					SecretKeyRef: &corev1.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{
+							Name: rf.Spec.Auth.SecretPath,
+						},
+						Key: "password",
+					},
+				},
+			})
+		}
+	}
+	return env
+}
+
+func envExists(env []corev1.EnvVar, name string) bool {
+	for _, e := range env {
+		if e.Name == name {
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION
Fixes: The user provided exporter env gets overridden by the assumed environment.
