### PR TITLE
Making an ACL for the default user

### DIFF
--- a/operator/redisfailover/service/generator.go
+++ b/operator/redisfailover/service/generator.go
@@ -159,7 +159,7 @@ func generateRedisConfigMap(rf *redisfailoverv1.RedisFailover, labels map[string
 	redisConfigFileContent := tplOutput.String()
 
 	if password != "" {
-		redisConfigFileContent = fmt.Sprintf("%s\nmasterauth %s\nrequirepass %s", redisConfigFileContent, password, password)
+		redisConfigFileContent = fmt.Sprintf("%s\nuser default on >%s &* ~* +@all\nmasterauth %s\n", redisConfigFileContent, password, password)
 	}
 
 	return &corev1.ConfigMap{


### PR DESCRIPTION
Fixes #568 .

Operationally we could update an additional password on the master redis, and the replicas.

```
ACL SETUSR default on >newpassword
```

Then update the password on the secret. This ensures the operator is able to auth with the master. Then...

1. Restart the sentinels
2. Restart the redis(first replicas and then the master)
