### PR TITLE
add immutable config items by annotation

### DIFF
--- a/operator/redisfailover/service/generator.go
+++ b/operator/redisfailover/service/generator.go
@@ -146,9 +146,11 @@ func generateRedisConfigMap(rf *redisfailoverv1.RedisFailover, labels map[string
 	name := GetRedisName(rf)
 
 	var addConfigLines []string
-	for key, value := range rf.Annotations {
-		if strings.HasPrefix(key, "add-configuration-snippet/") {
-			addConfigLines = append(addConfigLines, value)
+	if rf.Annotations != nil {
+		for key, value := range rf.Annotations {
+			if strings.HasPrefix(key, "add-configuration-snippet") {
+				addConfigLines = append(addConfigLines, value)
+			}
 		}
 	}
 


### PR DESCRIPTION
allows to add immutable configuration settings to redis.conf template as annotation

```
metadata:
    annotations:
        add-configuration-snippet: |
          server_cpulist 0,2,4
          bio_cpulist 1
          aof_rewrite_cpulist 3
          bgsave_cpulist 3
          io-threads 2
          io-threads-do-reads no
```