### PR TITLE
Reduce number of calls made to k8s api server

### DIFF
--- a/cmd/redisoperator/main.go
+++ b/cmd/redisoperator/main.go
@@ -79,7 +79,7 @@ func (m *Main) Run() error {
 	}
 
 	// Create kubernetes service.
-	k8sservice := k8s.New(k8sClient, customClient, aeClientset, m.logger, metricsRecorder)
+	k8sservice := k8s.New(k8sClient, customClient, aeClientset, m.logger, metricsRecorder, m.flags.UseCache)
 
 	// Create the redis clients
 	redisClient := redis.New(metricsRecorder)

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -19,6 +19,7 @@ type CMDFlags struct {
 	K8sQueriesBurstable int
 	Concurrency         int
 	LogLevel            string
+	UseCache            bool
 }
 
 // Init initializes and parse the flags
@@ -35,6 +36,7 @@ func (c *CMDFlags) Init() {
 	// reference: https://github.com/spotahome/kooper/blob/master/controller/controller.go#L89
 	flag.IntVar(&c.Concurrency, "concurrency", 3, "Number of conccurent workers meant to process events")
 	flag.StringVar(&c.LogLevel, "log-level", "info", "set log level")
+	flag.BoolVar(&c.UseCache, "use-cache", false, "use cache stores to get k8s objects")
 	// Parse flags
 	flag.Parse()
 }

--- a/operator/redisfailover/ensurer.go
+++ b/operator/redisfailover/ensurer.go
@@ -9,6 +9,7 @@ import (
 
 // Ensure is called to ensure all of the resources associated with a RedisFailover are created
 func (w *RedisFailoverHandler) Ensure(rf *redisfailoverv1.RedisFailover, labels map[string]string, or []metav1.OwnerReference, metricsClient metrics.Recorder) error {
+
 	if rf.Spec.Redis.Exporter.Enabled {
 		if err := w.rfService.EnsureRedisService(rf, labels, or); err != nil {
 			return err

--- a/operator/redisfailover/service/client.go
+++ b/operator/redisfailover/service/client.go
@@ -158,6 +158,7 @@ func (r *RedisFailoverKubeClient) EnsureNotPresentRedisService(rf *redisfailover
 	namespace := rf.Namespace
 	// If the service exists (no get error), delete it
 	if _, err := r.K8SService.GetService(namespace, name); err == nil {
+		r.logger.Infof("deleting svc %v...", name)
 		return r.K8SService.DeleteService(namespace, name)
 	}
 	return nil

--- a/service/k8s/configmap.go
+++ b/service/k8s/configmap.go
@@ -2,11 +2,13 @@ package k8s
 
 import (
 	"context"
+	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/cache"
 
 	"github.com/spotahome/redis-operator/log"
 	"github.com/spotahome/redis-operator/metrics"
@@ -26,26 +28,48 @@ type ConfigMap interface {
 type ConfigMapService struct {
 	kubeClient      kubernetes.Interface
 	logger          log.Logger
+	cacheStore      *cache.Store
 	metricsRecorder metrics.Recorder
 }
 
 // NewConfigMapService returns a new ConfigMap KubeService.
-func NewConfigMapService(kubeClient kubernetes.Interface, logger log.Logger, metricsRecorder metrics.Recorder) *ConfigMapService {
+func NewConfigMapService(kubeClient kubernetes.Interface, logger log.Logger, metricsRecorder metrics.Recorder, useCache bool) *ConfigMapService {
 	logger = logger.With("service", "k8s.configMap")
+
+	// rc := kubeClient.CoreV1().RESTClient().(*rest.RESTClient)
+	var cmCacheStore *cache.Store
+	// if !useCache {
+	// 	cmCacheStore = ConfigMapCacheStoreFromKubeClient(rc)
+	// }
 	return &ConfigMapService{
 		kubeClient:      kubeClient,
 		logger:          logger,
+		cacheStore:      cmCacheStore,
 		metricsRecorder: metricsRecorder,
 	}
 }
 
 func (p *ConfigMapService) GetConfigMap(namespace string, name string) (*corev1.ConfigMap, error) {
-	configMap, err := p.kubeClient.CoreV1().ConfigMaps(namespace).Get(context.TODO(), name, metav1.GetOptions{})
-	recordMetrics(namespace, "ConfigMap", name, "GET", err, p.metricsRecorder)
-	if err != nil {
-		return nil, err
+	var cm *corev1.ConfigMap
+	var err error
+	var exists bool
+	if p.cacheStore != nil {
+		c := *p.cacheStore
+		var item interface{}
+		item, exists, err = c.GetByKey(fmt.Sprintf("%v/%v", namespace, name))
+		if exists && nil == err {
+			cm = item.(*corev1.ConfigMap)
+		}
+		if !exists {
+			err = fmt.Errorf("configmap %v not found in namespace %v", name, namespace)
+		}
+	} else {
+		cm, err = p.kubeClient.CoreV1().ConfigMaps(namespace).Get(context.TODO(), name, metav1.GetOptions{})
 	}
-	return configMap, err
+
+	recordMetrics(namespace, "ConfigMap", name, "GET", err, p.metricsRecorder)
+
+	return cm, err
 }
 
 func (p *ConfigMapService) CreateConfigMap(namespace string, configMap *corev1.ConfigMap) error {

--- a/service/k8s/configmap_test.go
+++ b/service/k8s/configmap_test.go
@@ -104,7 +104,7 @@ func TestConfigMapServiceGetCreateOrUpdate(t *testing.T) {
 				return true, nil, test.errorOnCreation
 			})
 
-			service := k8s.NewConfigMapService(mcli, log.Dummy, metrics.Dummy)
+			service := k8s.NewConfigMapService(mcli, log.Dummy, metrics.Dummy, false)
 			err := service.CreateOrUpdateConfigMap(testns, test.configMap)
 
 			if test.expErr {

--- a/service/k8s/deployment.go
+++ b/service/k8s/deployment.go
@@ -10,6 +10,8 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/cache"
 
 	"github.com/spotahome/redis-operator/log"
 	"github.com/spotahome/redis-operator/metrics"
@@ -30,26 +32,45 @@ type Deployment interface {
 type DeploymentService struct {
 	kubeClient      kubernetes.Interface
 	logger          log.Logger
+	cacheStore      *cache.Store
 	metricsRecorder metrics.Recorder
 }
 
 // NewDeploymentService returns a new Deployment KubeService.
-func NewDeploymentService(kubeClient kubernetes.Interface, logger log.Logger, metricsRecorder metrics.Recorder) *DeploymentService {
+func NewDeploymentService(kubeClient kubernetes.Interface, logger log.Logger, metricsRecorder metrics.Recorder, useCache bool) *DeploymentService {
 	logger = logger.With("service", "k8s.deployment")
+	rc := kubeClient.AppsV1().RESTClient().(*rest.RESTClient)
+	var cacheStore *cache.Store
+	if useCache {
+		cacheStore = DeploymentCacheStoreFromKubeClient(rc)
+	}
 	return &DeploymentService{
 		kubeClient:      kubeClient,
 		logger:          logger,
+		cacheStore:      cacheStore,
 		metricsRecorder: metricsRecorder,
 	}
 }
 
 // GetDeployment will retrieve the requested deployment based on namespace and name
 func (d *DeploymentService) GetDeployment(namespace, name string) (*appsv1.Deployment, error) {
-	deployment, err := d.kubeClient.AppsV1().Deployments(namespace).Get(context.TODO(), name, metav1.GetOptions{})
-	recordMetrics(namespace, "Deployment", name, "GET", err, d.metricsRecorder)
-	if err != nil {
-		return nil, err
+	var deployment *appsv1.Deployment
+	var err error
+	var exists bool
+	if d.cacheStore != nil {
+		c := *d.cacheStore
+		var item interface{}
+		item, exists, err = c.GetByKey(fmt.Sprintf("%v/%v", namespace, name))
+		if exists && nil == err {
+			deployment = item.(*appsv1.Deployment)
+		}
+		if !exists {
+			err = fmt.Errorf("deployment %v not found in namespace %v", name, namespace)
+		}
+	} else {
+		deployment, err = d.kubeClient.AppsV1().Deployments(namespace).Get(context.TODO(), name, metav1.GetOptions{})
 	}
+	recordMetrics(namespace, "Deployment", name, "GET", err, d.metricsRecorder)
 	return deployment, err
 }
 

--- a/service/k8s/deployment_test.go
+++ b/service/k8s/deployment_test.go
@@ -104,7 +104,7 @@ func TestDeploymentServiceGetCreateOrUpdate(t *testing.T) {
 				return true, nil, test.errorOnCreation
 			})
 
-			service := k8s.NewDeploymentService(mcli, log.Dummy, metrics.Dummy)
+			service := k8s.NewDeploymentService(mcli, log.Dummy, metrics.Dummy, false)
 			err := service.CreateOrUpdateDeployment(testns, test.deployment)
 
 			if test.expErr {

--- a/service/k8s/k8s.go
+++ b/service/k8s/k8s.go
@@ -35,16 +35,16 @@ type services struct {
 }
 
 // New returns a new Kubernetes service.
-func New(kubecli kubernetes.Interface, crdcli redisfailoverclientset.Interface, apiextcli apiextensionscli.Interface, logger log.Logger, metricsRecorder metrics.Recorder) Services {
+func New(kubecli kubernetes.Interface, crdcli redisfailoverclientset.Interface, apiextcli apiextensionscli.Interface, logger log.Logger, metricsRecorder metrics.Recorder, useCache bool) Services {
 	return &services{
-		ConfigMap:           NewConfigMapService(kubecli, logger, metricsRecorder),
-		Secret:              NewSecretService(kubecli, logger, metricsRecorder),
-		Pod:                 NewPodService(kubecli, logger, metricsRecorder),
-		PodDisruptionBudget: NewPodDisruptionBudgetService(kubecli, logger, metricsRecorder),
+		ConfigMap:           NewConfigMapService(kubecli, logger, metricsRecorder, useCache),
+		Secret:              NewSecretService(kubecli, logger, metricsRecorder, useCache),
+		Pod:                 NewPodService(kubecli, logger, metricsRecorder, useCache),
+		PodDisruptionBudget: NewPodDisruptionBudgetService(kubecli, logger, metricsRecorder, useCache),
 		RedisFailover:       NewRedisFailoverService(crdcli, logger, metricsRecorder),
-		Service:             NewServiceService(kubecli, logger, metricsRecorder),
-		RBAC:                NewRBACService(kubecli, logger, metricsRecorder),
-		Deployment:          NewDeploymentService(kubecli, logger, metricsRecorder),
-		StatefulSet:         NewStatefulSetService(kubecli, logger, metricsRecorder),
+		Service:             NewServiceService(kubecli, logger, metricsRecorder, useCache),
+		RBAC:                NewRBACService(kubecli, logger, metricsRecorder, useCache),
+		Deployment:          NewDeploymentService(kubecli, logger, metricsRecorder, useCache),
+		StatefulSet:         NewStatefulSetService(kubecli, logger, metricsRecorder, useCache),
 	}
 }

--- a/service/k8s/pod.go
+++ b/service/k8s/pod.go
@@ -3,16 +3,18 @@ package k8s
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 
 	"k8s.io/apimachinery/pkg/types"
 
+	"github.com/spotahome/redis-operator/log"
+	"github.com/spotahome/redis-operator/metrics"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
-
-	"github.com/spotahome/redis-operator/log"
-	"github.com/spotahome/redis-operator/metrics"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/cache"
 )
 
 // Pod the ServiceAccount service that knows how to interact with k8s to manage them
@@ -30,25 +32,47 @@ type Pod interface {
 type PodService struct {
 	kubeClient      kubernetes.Interface
 	logger          log.Logger
+	cacheStore      *cache.Store
 	metricsRecorder metrics.Recorder
 }
 
 // NewPodService returns a new Pod KubeService.
-func NewPodService(kubeClient kubernetes.Interface, logger log.Logger, metricsRecorder metrics.Recorder) *PodService {
+func NewPodService(kubeClient kubernetes.Interface, logger log.Logger, metricsRecorder metrics.Recorder, useCache bool) *PodService {
 	logger = logger.With("service", "k8s.pod")
+	rc := kubeClient.CoreV1().RESTClient().(*rest.RESTClient)
+	var podCacheStore *cache.Store
+	if useCache {
+		podCacheStore = PodCacheStoreFromKubeClient(rc)
+	}
+
 	return &PodService{
 		kubeClient:      kubeClient,
 		logger:          logger,
+		cacheStore:      podCacheStore,
 		metricsRecorder: metricsRecorder,
 	}
 }
 
 func (p *PodService) GetPod(namespace string, name string) (*corev1.Pod, error) {
-	pod, err := p.kubeClient.CoreV1().Pods(namespace).Get(context.TODO(), name, metav1.GetOptions{})
-	recordMetrics(namespace, "Pod", name, "GET", err, p.metricsRecorder)
-	if err != nil {
-		return nil, err
+	var pod *corev1.Pod
+	var err error
+	var exists bool
+	if p.cacheStore != nil {
+
+		c := *p.cacheStore
+		var item interface{}
+		item, exists, err = c.GetByKey(fmt.Sprintf("%v/%v", namespace, name))
+		if exists && nil == err {
+			pod = item.(*corev1.Pod)
+		}
+		if !exists {
+			err = fmt.Errorf("pod %v not found in namespace %v", name, namespace)
+		}
+	} else {
+		pod, err = p.kubeClient.CoreV1().Pods(namespace).Get(context.TODO(), name, metav1.GetOptions{})
+
 	}
+	recordMetrics(namespace, "Pod", name, "GET", err, p.metricsRecorder)
 	return pod, err
 }
 

--- a/service/k8s/pod_test.go
+++ b/service/k8s/pod_test.go
@@ -104,7 +104,7 @@ func TestPodServiceGetCreateOrUpdate(t *testing.T) {
 				return true, nil, test.errorOnCreation
 			})
 
-			service := k8s.NewPodService(mcli, log.Dummy, metrics.Dummy)
+			service := k8s.NewPodService(mcli, log.Dummy, metrics.Dummy, false)
 			err := service.CreateOrUpdatePod(testns, test.pod)
 
 			if test.expErr {

--- a/service/k8s/poddisruptionbudget.go
+++ b/service/k8s/poddisruptionbudget.go
@@ -2,11 +2,14 @@ package k8s
 
 import (
 	"context"
+	"fmt"
 
 	policyv1 "k8s.io/api/policy/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/cache"
 
 	"github.com/spotahome/redis-operator/log"
 	"github.com/spotahome/redis-operator/metrics"
@@ -25,26 +28,50 @@ type PodDisruptionBudget interface {
 type PodDisruptionBudgetService struct {
 	kubeClient      kubernetes.Interface
 	logger          log.Logger
+	cacheStore      *cache.Store
 	metricsRecorder metrics.Recorder
 }
 
 // NewPodDisruptionBudgetService returns a new PodDisruptionBudget KubeService.
-func NewPodDisruptionBudgetService(kubeClient kubernetes.Interface, logger log.Logger, metricsRecorder metrics.Recorder) *PodDisruptionBudgetService {
+func NewPodDisruptionBudgetService(kubeClient kubernetes.Interface, logger log.Logger, metricsRecorder metrics.Recorder, useCache bool) *PodDisruptionBudgetService {
 	logger = logger.With("service", "k8s.podDisruptionBudget")
+
+	rc := kubeClient.PolicyV1().RESTClient().(*rest.RESTClient)
+	var cacheStore *cache.Store
+	if useCache {
+		cacheStore = PodDisruptionBudgetCacheStoreFromKubeClient(rc)
+	}
+
 	return &PodDisruptionBudgetService{
 		kubeClient:      kubeClient,
 		logger:          logger,
+		cacheStore:      cacheStore,
 		metricsRecorder: metricsRecorder,
 	}
 }
 
 func (p *PodDisruptionBudgetService) GetPodDisruptionBudget(namespace string, name string) (*policyv1.PodDisruptionBudget, error) {
-	podDisruptionBudget, err := p.kubeClient.PolicyV1().PodDisruptionBudgets(namespace).Get(context.TODO(), name, metav1.GetOptions{})
-	recordMetrics(namespace, "PodDisruptionBudget", name, "GET", err, p.metricsRecorder)
-	if err != nil {
-		return nil, err
+	var podDisruptionBudget *policyv1.PodDisruptionBudget
+	var err error
+	var exists bool
+
+	if p.cacheStore != nil {
+		c := *p.cacheStore
+		var item interface{}
+		item, exists, err = c.GetByKey(fmt.Sprintf("%v/%v", namespace, name))
+		if exists && nil == err {
+			podDisruptionBudget = item.(*policyv1.PodDisruptionBudget)
+		}
+		if !exists {
+
+			err = fmt.Errorf("podDisruptionBudget %v not found in namespace %v", name, namespace)
+		}
+	} else {
+		podDisruptionBudget, err = p.kubeClient.PolicyV1().PodDisruptionBudgets(namespace).Get(context.TODO(), name, metav1.GetOptions{})
 	}
-	return podDisruptionBudget, nil
+	recordMetrics(namespace, "PodDisruptionBudget", name, "GET", err, p.metricsRecorder)
+
+	return podDisruptionBudget, err
 }
 
 func (p *PodDisruptionBudgetService) CreatePodDisruptionBudget(namespace string, podDisruptionBudget *policyv1.PodDisruptionBudget) error {

--- a/service/k8s/poddisruptionbudget_test.go
+++ b/service/k8s/poddisruptionbudget_test.go
@@ -102,7 +102,7 @@ func TestPodDisruptionBudgetServiceGetCreateOrUpdate(t *testing.T) {
 				return true, nil, test.errorOnCreation
 			})
 
-			service := k8s.NewPodDisruptionBudgetService(mcli, log.Dummy, metrics.Dummy)
+			service := k8s.NewPodDisruptionBudgetService(mcli, log.Dummy, metrics.Dummy, false)
 			err := service.CreateOrUpdatePodDisruptionBudget(testns, test.podDisruptionBudget)
 
 			if test.expErr {

--- a/service/k8s/rbac.go
+++ b/service/k8s/rbac.go
@@ -2,11 +2,14 @@ package k8s
 
 import (
 	"context"
+	"fmt"
 
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/cache"
 
 	"github.com/spotahome/redis-operator/log"
 	"github.com/spotahome/redis-operator/metrics"
@@ -27,37 +30,107 @@ type RBAC interface {
 
 // NamespaceService is the Namespace service implementation using API calls to kubernetes.
 type RBACService struct {
-	kubeClient      kubernetes.Interface
-	logger          log.Logger
-	metricsRecorder metrics.Recorder
+	kubeClient            kubernetes.Interface
+	logger                log.Logger
+	roleCacheStore        *cache.Store
+	roleBindingCacheStore *cache.Store
+	clusterRoleCacheStore *cache.Store
+	metricsRecorder       metrics.Recorder
 }
 
 // NewRBACService returns a new RBAC KubeService.
-func NewRBACService(kubeClient kubernetes.Interface, logger log.Logger, metricsRecorder metrics.Recorder) *RBACService {
+func NewRBACService(kubeClient kubernetes.Interface, logger log.Logger, metricsRecorder metrics.Recorder, useCache bool) *RBACService {
 	logger = logger.With("service", "k8s.rbac")
+
+	rc := kubeClient.RbacV1().RESTClient().(*rest.RESTClient)
+
+	var roleCacheStore *cache.Store
+	var roleBindingCacheStore *cache.Store
+	var clusterRoleCacheStore *cache.Store
+
+	if useCache {
+		roleCacheStore = RoleCacheStoreFromKubeClient(rc)
+		roleBindingCacheStore = RoleBindingCacheStoreFromKubeClient(rc)
+		clusterRoleCacheStore = ClusterRoleCacheStoreFromKubeClient(rc)
+	}
+
 	return &RBACService{
-		kubeClient:      kubeClient,
-		logger:          logger,
-		metricsRecorder: metricsRecorder,
+		kubeClient:            kubeClient,
+		logger:                logger,
+		roleCacheStore:        roleCacheStore,
+		roleBindingCacheStore: roleBindingCacheStore,
+		clusterRoleCacheStore: clusterRoleCacheStore,
+		metricsRecorder:       metricsRecorder,
 	}
 }
 
 func (r *RBACService) GetClusterRole(name string) (*rbacv1.ClusterRole, error) {
-	clusterRole, err := r.kubeClient.RbacV1().ClusterRoles().Get(context.TODO(), name, metav1.GetOptions{})
+	var clusterRole *rbacv1.ClusterRole
+	var err error
+	var exists bool
+	if r.clusterRoleCacheStore != nil {
+
+		c := *r.clusterRoleCacheStore
+		var item interface{}
+		item, exists, err = c.GetByKey(fmt.Sprintf("%v", name))
+		if exists && nil == err {
+			clusterRole = item.(*rbacv1.ClusterRole)
+		}
+
+		if !exists {
+			err = fmt.Errorf("clusterRole %v not found", name)
+		}
+
+	} else {
+		clusterRole, err = r.kubeClient.RbacV1().ClusterRoles().Get(context.TODO(), name, metav1.GetOptions{})
+	}
 	recordMetrics(metrics.NOT_APPLICABLE, "ClusterRole", name, "GET", err, r.metricsRecorder)
 	return clusterRole, err
+
 }
 
 func (r *RBACService) GetRole(namespace, name string) (*rbacv1.Role, error) {
-	role, err := r.kubeClient.RbacV1().Roles(namespace).Get(context.TODO(), name, metav1.GetOptions{})
+	var role *rbacv1.Role
+	var err error
+	var exists bool
+	if r.roleCacheStore != nil {
+		c := *r.roleCacheStore
+		var item interface{}
+		item, exists, err = c.GetByKey(fmt.Sprintf("%v/%v", namespace, name))
+		if exists && nil == err {
+			role = item.(*rbacv1.Role)
+		}
+		if !exists {
+			err = fmt.Errorf("role %v not found in namespace %v", name, namespace)
+		}
+
+	} else {
+		role, err = r.kubeClient.RbacV1().Roles(namespace).Get(context.TODO(), name, metav1.GetOptions{})
+	}
+
 	recordMetrics(namespace, "Role", name, "GET", err, r.metricsRecorder)
 	return role, err
 }
 
 func (r *RBACService) GetRoleBinding(namespace, name string) (*rbacv1.RoleBinding, error) {
-	rolbinding, err := r.kubeClient.RbacV1().RoleBindings(namespace).Get(context.TODO(), name, metav1.GetOptions{})
+	var roleBinding *rbacv1.RoleBinding
+	var err error
+	var exists bool
+	if r.roleBindingCacheStore != nil {
+		c := *r.roleCacheStore
+		var item interface{}
+		item, exists, err = c.GetByKey(fmt.Sprintf("%v/%v", namespace, name))
+		if exists && nil == err {
+			roleBinding = item.(*rbacv1.RoleBinding)
+		}
+		if !exists {
+			err = fmt.Errorf("role binding %v not found in namespace %v", name, namespace)
+		}
+	} else {
+		roleBinding, err = r.kubeClient.RbacV1().RoleBindings(namespace).Get(context.TODO(), name, metav1.GetOptions{})
+	}
 	recordMetrics(namespace, "RoleBinding", name, "GET", err, r.metricsRecorder)
-	return rolbinding, err
+	return roleBinding, err
 }
 
 func (r *RBACService) DeleteRole(namespace, name string) error {

--- a/service/k8s/rbac_test.go
+++ b/service/k8s/rbac_test.go
@@ -131,7 +131,7 @@ func TestRBACServiceGetCreateOrUpdateRoleBinding(t *testing.T) {
 				return true, nil, test.errorOnCreation
 			})
 
-			service := k8s.NewRBACService(mcli, log.Dummy, metrics.Dummy)
+			service := k8s.NewRBACService(mcli, log.Dummy, metrics.Dummy, false)
 			err := service.CreateOrUpdateRoleBinding(testns, test.rb)
 
 			if test.expErr {

--- a/service/k8s/secret.go
+++ b/service/k8s/secret.go
@@ -2,12 +2,15 @@ package k8s
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/spotahome/redis-operator/log"
 	"github.com/spotahome/redis-operator/metrics"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/cache"
 )
 
 // Secret interacts with k8s to get secrets
@@ -19,26 +22,45 @@ type Secret interface {
 type SecretService struct {
 	kubeClient      kubernetes.Interface
 	logger          log.Logger
+	cacheStore      *cache.Store
 	metricsRecorder metrics.Recorder
 }
 
-func NewSecretService(kubeClient kubernetes.Interface, logger log.Logger, metricsRecorder metrics.Recorder) *SecretService {
+func NewSecretService(kubeClient kubernetes.Interface, logger log.Logger, metricsRecorder metrics.Recorder, useCache bool) *SecretService {
 
 	logger = logger.With("service", "k8s.secret")
+	rc := kubeClient.CoreV1().RESTClient().(*rest.RESTClient)
+	var cacheStore *cache.Store
+	if useCache {
+		cacheStore = SecretCacheStoreFromKubeClient(rc)
+	}
 	return &SecretService{
 		kubeClient:      kubeClient,
 		logger:          logger,
+		cacheStore:      cacheStore,
 		metricsRecorder: metricsRecorder,
 	}
 }
 
 func (s *SecretService) GetSecret(namespace, name string) (*corev1.Secret, error) {
-
-	secret, err := s.kubeClient.CoreV1().Secrets(namespace).Get(context.TODO(), name, metav1.GetOptions{})
-	recordMetrics(namespace, "Secret", name, "GET", err, s.metricsRecorder)
-	if err != nil {
-		return nil, err
+	var secret *corev1.Secret
+	var err error
+	var exists bool
+	if s.cacheStore != nil {
+		c := *s.cacheStore
+		var item interface{}
+		item, exists, err = c.GetByKey(fmt.Sprintf("%v/%v", namespace, name))
+		if exists && nil == err {
+			secret = item.(*corev1.Secret)
+		}
+		if !exists {
+			err = fmt.Errorf("secret %v not found in namespace %v", name, namespace)
+		}
+	} else {
+		secret, err = s.kubeClient.CoreV1().Secrets(namespace).Get(context.TODO(), name, metav1.GetOptions{})
 	}
+
+	recordMetrics(namespace, "Secret", name, "GET", err, s.metricsRecorder)
 
 	return secret, err
 }

--- a/service/k8s/secret_test.go
+++ b/service/k8s/secret_test.go
@@ -47,7 +47,7 @@ func TestSecretServiceGet(t *testing.T) {
 		assert.NoError(err)
 
 		// test getting the secret
-		service := NewSecretService(mcli, log.Dummy, metrics.Dummy)
+		service := NewSecretService(mcli, log.Dummy, metrics.Dummy, false)
 		ss, err := service.GetSecret(secret.ObjectMeta.Namespace, secret.ObjectMeta.Name)
 		assert.NotNil(ss)
 		assert.NoError(err)

--- a/service/k8s/service.go
+++ b/service/k8s/service.go
@@ -2,11 +2,14 @@ package k8s
 
 import (
 	"context"
+	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/cache"
 
 	"github.com/spotahome/redis-operator/log"
 	"github.com/spotahome/redis-operator/metrics"
@@ -27,25 +30,47 @@ type Service interface {
 type ServiceService struct {
 	kubeClient      kubernetes.Interface
 	logger          log.Logger
+	cacheStore      *cache.Store
 	metricsRecorder metrics.Recorder
 }
 
 // NewServiceService returns a new Service KubeService.
-func NewServiceService(kubeClient kubernetes.Interface, logger log.Logger, metricsRecorder metrics.Recorder) *ServiceService {
+func NewServiceService(kubeClient kubernetes.Interface, logger log.Logger, metricsRecorder metrics.Recorder, useCache bool) *ServiceService {
 	logger = logger.With("service", "k8s.service")
+
+	rc := kubeClient.CoreV1().RESTClient().(*rest.RESTClient)
+	var cacheStore *cache.Store
+
+	if useCache {
+		cacheStore = ServiceCacheStoreFromKubeClient(rc)
+	}
+
 	return &ServiceService{
 		kubeClient:      kubeClient,
 		logger:          logger,
+		cacheStore:      cacheStore,
 		metricsRecorder: metricsRecorder,
 	}
 }
 
 func (s *ServiceService) GetService(namespace string, name string) (*corev1.Service, error) {
-	service, err := s.kubeClient.CoreV1().Services(namespace).Get(context.TODO(), name, metav1.GetOptions{})
-	recordMetrics(namespace, "Service", name, "GET", err, s.metricsRecorder)
-	if err != nil {
-		return nil, err
+	var service *corev1.Service
+	var err error
+	var exists bool
+	if s.cacheStore != nil {
+		c := *s.cacheStore
+		var item interface{}
+		item, exists, err = c.GetByKey(fmt.Sprintf("%v/%v", namespace, name))
+		if exists && nil == err {
+			service = item.(*corev1.Service)
+		}
+		if !exists {
+			err = fmt.Errorf("svc %v/%v not found", namespace, name)
+		}
+	} else {
+		service, err = s.kubeClient.CoreV1().Services(namespace).Get(context.TODO(), name, metav1.GetOptions{})
 	}
+	recordMetrics(namespace, "Service", name, "GET", err, s.metricsRecorder)
 	return service, err
 }
 

--- a/service/k8s/service_test.go
+++ b/service/k8s/service_test.go
@@ -104,7 +104,7 @@ func TestServiceServiceGetCreateOrUpdate(t *testing.T) {
 				return true, nil, test.errorOnCreation
 			})
 
-			service := k8s.NewServiceService(mcli, log.Dummy, metrics.Dummy)
+			service := k8s.NewServiceService(mcli, log.Dummy, metrics.Dummy, false)
 			err := service.CreateOrUpdateService(testns, test.service)
 
 			if test.expErr {

--- a/service/k8s/statefulset.go
+++ b/service/k8s/statefulset.go
@@ -15,6 +15,8 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/cache"
 
 	"github.com/spotahome/redis-operator/log"
 	"github.com/spotahome/redis-operator/metrics"
@@ -35,27 +37,48 @@ type StatefulSet interface {
 type StatefulSetService struct {
 	kubeClient      kubernetes.Interface
 	logger          log.Logger
+	cacheStore      *cache.Store
 	metricsRecorder metrics.Recorder
 }
 
 // NewStatefulSetService returns a new StatefulSet KubeService.
-func NewStatefulSetService(kubeClient kubernetes.Interface, logger log.Logger, metricsRecorder metrics.Recorder) *StatefulSetService {
+func NewStatefulSetService(kubeClient kubernetes.Interface, logger log.Logger, metricsRecorder metrics.Recorder, useCache bool) *StatefulSetService {
 	logger = logger.With("service", "k8s.statefulSet")
+
+	rc := kubeClient.AppsV1().RESTClient().(*rest.RESTClient)
+	var cacheStore *cache.Store
+	if useCache {
+		cacheStore = StatefulSetCacheStoreFromKubeClient(rc)
+	}
 	return &StatefulSetService{
 		kubeClient:      kubeClient,
 		logger:          logger,
+		cacheStore:      cacheStore,
 		metricsRecorder: metricsRecorder,
 	}
 }
 
 // GetStatefulSet will retrieve the requested statefulset based on namespace and name
 func (s *StatefulSetService) GetStatefulSet(namespace, name string) (*appsv1.StatefulSet, error) {
-	statefulSet, err := s.kubeClient.AppsV1().StatefulSets(namespace).Get(context.TODO(), name, metav1.GetOptions{})
-	recordMetrics(namespace, "StatefulSet", name, "GET", err, s.metricsRecorder)
-	if err != nil {
-		return nil, err
+	var ss *appsv1.StatefulSet
+	var err error
+	var exists bool
+	if s.cacheStore != nil {
+		c := *s.cacheStore
+		var item interface{}
+		item, exists, err = c.GetByKey(fmt.Sprintf("%v/%v", namespace, name))
+		if exists && nil == err {
+			ss = item.(*appsv1.StatefulSet)
+		}
+		if !exists {
+			err = fmt.Errorf("statefulset %s not found in namespace %v", name, namespace)
+		}
+	} else {
+		ss, err = s.kubeClient.AppsV1().StatefulSets(namespace).Get(context.TODO(), name, metav1.GetOptions{})
 	}
-	return statefulSet, err
+
+	recordMetrics(namespace, "StatefulSet", name, "GET", err, s.metricsRecorder)
+	return ss, err
 }
 
 // GetStatefulSetPods will give a list of pods that are managed by the statefulset

--- a/service/k8s/statefulset_test.go
+++ b/service/k8s/statefulset_test.go
@@ -108,7 +108,7 @@ func TestStatefulSetServiceGetCreateOrUpdate(t *testing.T) {
 				return true, nil, test.errorOnCreation
 			})
 
-			service := k8s.NewStatefulSetService(mcli, log.Dummy, metrics.Dummy)
+			service := k8s.NewStatefulSetService(mcli, log.Dummy, metrics.Dummy, false)
 			err := service.CreateOrUpdateStatefulSet(testns, test.statefulSet)
 
 			if test.expErr {
@@ -207,7 +207,7 @@ func TestStatefulSetServiceGetCreateOrUpdate(t *testing.T) {
 				pvcList.Items[0] = *action.(kubetesting.UpdateActionImpl).Object.(*v1.PersistentVolumeClaim)
 				return true, action.(kubetesting.UpdateActionImpl).Object, nil
 			})
-			service := k8s.NewStatefulSetService(mcli, log.Dummy, metrics.Dummy)
+			service := k8s.NewStatefulSetService(mcli, log.Dummy, metrics.Dummy, false)
 			err := service.CreateOrUpdateStatefulSet(testns, afterSts)
 			assert.NoError(err)
 			assert.Equal(pvcList.Items[0].Spec.Resources, pvcList.Items[1].Spec.Resources)
@@ -215,7 +215,7 @@ func TestStatefulSetServiceGetCreateOrUpdate(t *testing.T) {
 			mcli.AddReactor("update", "persistentvolumeclaims", func(action kubetesting.Action) (handled bool, ret runtime.Object, err error) {
 				panic("shouldn't call update")
 			})
-			service = k8s.NewStatefulSetService(mcli, log.Dummy, metrics.Dummy)
+			service = k8s.NewStatefulSetService(mcli, log.Dummy, metrics.Dummy, false)
 			err = service.CreateOrUpdateStatefulSet(testns, afterSts)
 			assert.NoError(err)
 		})


### PR DESCRIPTION
# Reduce calls made to API server
Changes proposed on the PR:
- all "get" calls now optionally via client side cache.

this change can improve performance when using high number of RF objects.

Below is api server usage with 3 redis failover objects
- there are 3 segments in this graph
  - first one is without caching
  - second one is with caching
  - third one is when redis-operator is not running.

<img width="1650" alt="Screenshot 2023-04-09 at 9 21 29 PM" src="https://user-images.githubusercontent.com/113178711/230782941-12dc038d-ec20-41be-b0ee-ababbb6ebd3f.png">
