### PR TITLE
do not propagate labels by default

### DIFF
--- a/operator/redisfailover/handler.go
+++ b/operator/redisfailover/handler.go
@@ -106,9 +106,6 @@ func (r *RedisFailoverHandler) getLabels(rf *redisfailoverv1.RedisFailover) map[
 				}
 			}
 		}
-	} else {
-		// If no whitelist is specified then don't filter the labels.
-		filteredCustomLabels = rf.Labels
 	}
 	return util.MergeLabels(defaultLabels, dynLabels, filteredCustomLabels)
 }


### PR DESCRIPTION
Deployment tools like kubectl ApplySets use labels to keep track of objects they manage. Propagating those labels where a tool is actively pruning resources will cause resources managed by the operator to be pruned also.

https://kubernetes.io/blog/2023/05/09/introducing-kubectl-applyset-pruning/

Fixes #592