### PR TITLE
Support modify pdb minAvailable from `CMDFlags`

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -19,6 +19,7 @@ type CMDFlags struct {
 	K8sQueriesBurstable int
 	Concurrency         int
 	LogLevel            string
+	PDBMinAvailable     string
 }
 
 // Init initializes and parse the flags
@@ -35,6 +36,7 @@ func (c *CMDFlags) Init() {
 	// reference: https://github.com/spotahome/kooper/blob/master/controller/controller.go#L89
 	flag.IntVar(&c.Concurrency, "concurrency", 3, "Number of conccurent workers meant to process events")
 	flag.StringVar(&c.LogLevel, "log-level", "info", "set log level")
+	flag.StringVar(&c.PDBMinAvailable, "pdb-minAvailable", "2", "set default pdb min available value")
 	// Parse flags
 	flag.Parse()
 }
@@ -42,8 +44,9 @@ func (c *CMDFlags) Init() {
 // ToRedisOperatorConfig convert the flags to redisfailover config
 func (c *CMDFlags) ToRedisOperatorConfig() redisfailover.Config {
 	return redisfailover.Config{
-		ListenAddress: c.ListenAddr,
-		MetricsPath:   c.MetricsPath,
-		Concurrency:   c.Concurrency,
+		ListenAddress:   c.ListenAddr,
+		MetricsPath:     c.MetricsPath,
+		Concurrency:     c.Concurrency,
+		PDBMinAvailable: c.PDBMinAvailable,
 	}
 }

--- a/cmd/utils/flags_test.go
+++ b/cmd/utils/flags_test.go
@@ -1,0 +1,14 @@
+package utils
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCMDFlags_Init(t *testing.T) {
+	assert := assert.New(t)
+	flags := CMDFlags{}
+	flags.Init()
+	assert.Equal(flags.PDBMinAvailable, "2")
+}

--- a/operator/redisfailover/config.go
+++ b/operator/redisfailover/config.go
@@ -2,7 +2,8 @@ package redisfailover
 
 // Config is the configuration for the redis operator.
 type Config struct {
-	ListenAddress string
-	MetricsPath   string
-	Concurrency   int
+	ListenAddress   string
+	MetricsPath     string
+	Concurrency     int
+	PDBMinAvailable string
 }

--- a/operator/redisfailover/factory.go
+++ b/operator/redisfailover/factory.go
@@ -30,7 +30,7 @@ const (
 // to create redis failovers.
 func New(cfg Config, k8sService k8s.Services, k8sClient kubernetes.Interface, lockNamespace string, redisClient redis.Client, kooperMetricsRecorder metrics.Recorder, logger log.Logger) (controller.Controller, error) {
 	// Create internal services.
-	rfService := rfservice.NewRedisFailoverKubeClient(k8sService, logger, kooperMetricsRecorder)
+	rfService := rfservice.NewRedisFailoverKubeClient(k8sService, logger, kooperMetricsRecorder, cfg.PDBMinAvailable)
 	rfChecker := rfservice.NewRedisFailoverChecker(k8sService, redisClient, logger, kooperMetricsRecorder)
 	rfHealer := rfservice.NewRedisFailoverHealer(k8sService, redisClient, logger)
 

--- a/operator/redisfailover/service/client.go
+++ b/operator/redisfailover/service/client.go
@@ -27,17 +27,19 @@ type RedisFailoverClient interface {
 
 // RedisFailoverKubeClient implements the required methods to talk with kubernetes
 type RedisFailoverKubeClient struct {
-	K8SService    k8s.Services
-	logger        log.Logger
-	metricsClient metrics.Recorder
+	K8SService      k8s.Services
+	logger          log.Logger
+	metricsClient   metrics.Recorder
+	pdbMinAvailable string
 }
 
 // NewRedisFailoverKubeClient creates a new RedisFailoverKubeClient
-func NewRedisFailoverKubeClient(k8sService k8s.Services, logger log.Logger, metricsClient metrics.Recorder) *RedisFailoverKubeClient {
+func NewRedisFailoverKubeClient(k8sService k8s.Services, logger log.Logger, metricsClient metrics.Recorder, pdbMinAvailable string) *RedisFailoverKubeClient {
 	return &RedisFailoverKubeClient{
-		K8SService:    k8sService,
-		logger:        logger,
-		metricsClient: metricsClient,
+		K8SService:      k8sService,
+		logger:          logger,
+		metricsClient:   metricsClient,
+		pdbMinAvailable: pdbMinAvailable,
 	}
 }
 
@@ -168,7 +170,7 @@ func (r *RedisFailoverKubeClient) ensurePodDisruptionBudget(rf *redisfailoverv1.
 	name = generateName(name, rf.Name)
 	namespace := rf.Namespace
 
-	minAvailable := intstr.FromInt(2)
+	minAvailable := intstr.FromString(r.pdbMinAvailable)
 	if rf.Spec.Redis.Replicas <= 2 {
 		minAvailable = intstr.FromInt(1)
 	}

--- a/operator/redisfailover/service/generator_test.go
+++ b/operator/redisfailover/service/generator_test.go
@@ -533,7 +533,7 @@ func TestRedisStatefulSetStorageGeneration(t *testing.T) {
 			generatedStatefulSet = *ss
 		}).Return(nil)
 
-		client := rfservice.NewRedisFailoverKubeClient(ms, log.Dummy, metrics.Dummy)
+		client := rfservice.NewRedisFailoverKubeClient(ms, log.Dummy, metrics.Dummy, "2")
 		err := client.EnsureRedisStatefulset(rf, nil, test.ownerRefs)
 
 		// Check that the storage-related fields are as spected
@@ -587,7 +587,7 @@ func TestRedisStatefulSetCommands(t *testing.T) {
 			gotCommands = ss.Spec.Template.Spec.Containers[0].Command
 		}).Return(nil)
 
-		client := rfservice.NewRedisFailoverKubeClient(ms, log.Dummy, metrics.Dummy)
+		client := rfservice.NewRedisFailoverKubeClient(ms, log.Dummy, metrics.Dummy, "2")
 		err := client.EnsureRedisStatefulset(rf, nil, []metav1.OwnerReference{})
 
 		assert.Equal(test.expectedCommands, gotCommands)
@@ -639,7 +639,7 @@ func TestSentinelDeploymentCommands(t *testing.T) {
 			gotCommands = d.Spec.Template.Spec.Containers[0].Command
 		}).Return(nil)
 
-		client := rfservice.NewRedisFailoverKubeClient(ms, log.Dummy, metrics.Dummy)
+		client := rfservice.NewRedisFailoverKubeClient(ms, log.Dummy, metrics.Dummy, "2")
 		err := client.EnsureSentinelDeployment(rf, nil, []metav1.OwnerReference{})
 
 		assert.Equal(test.expectedCommands, gotCommands)
@@ -687,7 +687,7 @@ func TestRedisStatefulSetPodAnnotations(t *testing.T) {
 			gotPodAnnotations = ss.Spec.Template.ObjectMeta.Annotations
 		}).Return(nil)
 
-		client := rfservice.NewRedisFailoverKubeClient(ms, log.Dummy, metrics.Dummy)
+		client := rfservice.NewRedisFailoverKubeClient(ms, log.Dummy, metrics.Dummy, "2")
 		err := client.EnsureRedisStatefulset(rf, nil, []metav1.OwnerReference{})
 
 		assert.Equal(test.expectedPodAnnotations, gotPodAnnotations)
@@ -735,7 +735,7 @@ func TestSentinelDeploymentPodAnnotations(t *testing.T) {
 			gotPodAnnotations = d.Spec.Template.ObjectMeta.Annotations
 		}).Return(nil)
 
-		client := rfservice.NewRedisFailoverKubeClient(ms, log.Dummy, metrics.Dummy)
+		client := rfservice.NewRedisFailoverKubeClient(ms, log.Dummy, metrics.Dummy, "2")
 		err := client.EnsureSentinelDeployment(rf, nil, []metav1.OwnerReference{})
 
 		assert.Equal(test.expectedPodAnnotations, gotPodAnnotations)
@@ -777,7 +777,7 @@ func TestRedisStatefulSetServiceAccountName(t *testing.T) {
 			gotServiceAccountName = ss.Spec.Template.Spec.ServiceAccountName
 		}).Return(nil)
 
-		client := rfservice.NewRedisFailoverKubeClient(ms, log.Dummy, metrics.Dummy)
+		client := rfservice.NewRedisFailoverKubeClient(ms, log.Dummy, metrics.Dummy, "2")
 		err := client.EnsureRedisStatefulset(rf, nil, []metav1.OwnerReference{})
 
 		assert.Equal(test.expectedServiceAccountName, gotServiceAccountName)
@@ -819,7 +819,7 @@ func TestSentinelDeploymentServiceAccountName(t *testing.T) {
 			gotServiceAccountName = d.Spec.Template.Spec.ServiceAccountName
 		}).Return(nil)
 
-		client := rfservice.NewRedisFailoverKubeClient(ms, log.Dummy, metrics.Dummy)
+		client := rfservice.NewRedisFailoverKubeClient(ms, log.Dummy, metrics.Dummy, "2")
 		err := client.EnsureSentinelDeployment(rf, nil, []metav1.OwnerReference{})
 
 		assert.Equal(test.expectedServiceAccountName, gotServiceAccountName)
@@ -1036,7 +1036,7 @@ func TestSentinelService(t *testing.T) {
 				generatedService = *s
 			}).Return(nil)
 
-			client := rfservice.NewRedisFailoverKubeClient(ms, log.Dummy, metrics.Dummy)
+			client := rfservice.NewRedisFailoverKubeClient(ms, log.Dummy, metrics.Dummy, "2")
 			err := client.EnsureSentinelService(rf, test.rfLabels, []metav1.OwnerReference{{Name: "testing"}})
 
 			assert.Equal(test.expectedService, generatedService)
@@ -1284,7 +1284,7 @@ func TestRedisService(t *testing.T) {
 				generatedService = *s
 			}).Return(nil)
 
-			client := rfservice.NewRedisFailoverKubeClient(ms, log.Dummy, metrics.Dummy)
+			client := rfservice.NewRedisFailoverKubeClient(ms, log.Dummy, metrics.Dummy, "2")
 			err := client.EnsureRedisService(rf, test.rfLabels, []metav1.OwnerReference{{Name: "testing"}})
 
 			assert.Equal(test.expectedService, generatedService)
@@ -1333,7 +1333,7 @@ func TestRedisHostNetworkAndDnsPolicy(t *testing.T) {
 			actualDnsPolicy = ss.Spec.Template.Spec.DNSPolicy
 		}).Return(nil)
 
-		client := rfservice.NewRedisFailoverKubeClient(ms, log.Dummy, metrics.Dummy)
+		client := rfservice.NewRedisFailoverKubeClient(ms, log.Dummy, metrics.Dummy, "2")
 		err := client.EnsureRedisStatefulset(rf, nil, []metav1.OwnerReference{})
 		assert.NoError(err)
 
@@ -1382,7 +1382,7 @@ func TestSentinelHostNetworkAndDnsPolicy(t *testing.T) {
 			actualDnsPolicy = d.Spec.Template.Spec.DNSPolicy
 		}).Return(nil)
 
-		client := rfservice.NewRedisFailoverKubeClient(ms, log.Dummy, metrics.Dummy)
+		client := rfservice.NewRedisFailoverKubeClient(ms, log.Dummy, metrics.Dummy, "2")
 		err := client.EnsureSentinelDeployment(rf, nil, []metav1.OwnerReference{})
 		assert.NoError(err)
 
@@ -1432,7 +1432,7 @@ func TestRedisImagePullPolicy(t *testing.T) {
 			exporterPolicy = ss.Spec.Template.Spec.Containers[1].ImagePullPolicy
 		}).Return(nil)
 
-		client := rfservice.NewRedisFailoverKubeClient(ms, log.Dummy, metrics.Dummy)
+		client := rfservice.NewRedisFailoverKubeClient(ms, log.Dummy, metrics.Dummy, "2")
 		err := client.EnsureRedisStatefulset(rf, nil, []metav1.OwnerReference{})
 
 		assert.NoError(err)
@@ -1478,7 +1478,7 @@ func TestSentinelImagePullPolicy(t *testing.T) {
 			configPolicy = d.Spec.Template.Spec.InitContainers[0].ImagePullPolicy
 		}).Return(nil)
 
-		client := rfservice.NewRedisFailoverKubeClient(ms, log.Dummy, metrics.Dummy)
+		client := rfservice.NewRedisFailoverKubeClient(ms, log.Dummy, metrics.Dummy, "2")
 		err := client.EnsureSentinelDeployment(rf, nil, []metav1.OwnerReference{})
 
 		assert.NoError(err)
@@ -1553,7 +1553,7 @@ func TestRedisExtraVolumeMounts(t *testing.T) {
 			extraVolumeMount = s.Spec.Template.Spec.Containers[0].VolumeMounts[4]
 		}).Return(nil)
 
-		client := rfservice.NewRedisFailoverKubeClient(ms, log.Dummy, metrics.Dummy)
+		client := rfservice.NewRedisFailoverKubeClient(ms, log.Dummy, metrics.Dummy, "2")
 		err := client.EnsureRedisStatefulset(rf, nil, []metav1.OwnerReference{})
 
 		assert.NoError(err)
@@ -1628,7 +1628,7 @@ func TestSentinelExtraVolumeMounts(t *testing.T) {
 			extraVolumeMount = d.Spec.Template.Spec.Containers[0].VolumeMounts[1]
 		}).Return(nil)
 
-		client := rfservice.NewRedisFailoverKubeClient(ms, log.Dummy, metrics.Dummy)
+		client := rfservice.NewRedisFailoverKubeClient(ms, log.Dummy, metrics.Dummy, "2")
 		err := client.EnsureSentinelDeployment(rf, nil, []metav1.OwnerReference{})
 
 		assert.NoError(err)
@@ -1684,7 +1684,7 @@ func TestCustomPort(t *testing.T) {
 			port = s.Spec.Template.Spec.Containers[0].Ports[0]
 		}).Return(nil)
 
-		client := rfservice.NewRedisFailoverKubeClient(ms, log.Dummy, metrics.Dummy)
+		client := rfservice.NewRedisFailoverKubeClient(ms, log.Dummy, metrics.Dummy, "2")
 		err := client.EnsureRedisStatefulset(rf, nil, []metav1.OwnerReference{})
 
 		assert.NoError(err)
@@ -1766,7 +1766,7 @@ func TestRedisEnv(t *testing.T) {
 			env = s.Spec.Template.Spec.Containers[0].Env
 		}).Return(nil)
 
-		client := rfservice.NewRedisFailoverKubeClient(ms, log.Dummy, metrics.Dummy)
+		client := rfservice.NewRedisFailoverKubeClient(ms, log.Dummy, metrics.Dummy, "2")
 		err := client.EnsureRedisStatefulset(rf, nil, []metav1.OwnerReference{})
 
 		assert.NoError(err)
@@ -1818,7 +1818,7 @@ func TestRedisStartupProbe(t *testing.T) {
 			startupVolumeMounts = s.Spec.Template.Spec.Containers[0].VolumeMounts
 		}).Return(nil)
 
-		client := rfservice.NewRedisFailoverKubeClient(ms, log.Dummy, metrics.Dummy)
+		client := rfservice.NewRedisFailoverKubeClient(ms, log.Dummy, metrics.Dummy, "2")
 		err := client.EnsureRedisStatefulset(rf, nil, []metav1.OwnerReference{})
 
 		assert.NoError(err)
@@ -1871,7 +1871,7 @@ func TestSentinelStartupProbe(t *testing.T) {
 			startupVolumeMounts = d.Spec.Template.Spec.Containers[0].VolumeMounts
 		}).Return(nil)
 
-		client := rfservice.NewRedisFailoverKubeClient(ms, log.Dummy, metrics.Dummy)
+		client := rfservice.NewRedisFailoverKubeClient(ms, log.Dummy, metrics.Dummy, "2")
 		err := client.EnsureSentinelDeployment(rf, nil, []metav1.OwnerReference{})
 
 		assert.NoError(err)
@@ -1954,7 +1954,7 @@ func TestRedisCustomLivenessProbe(t *testing.T) {
 			livenessProbe = s.Spec.Template.Spec.Containers[0].LivenessProbe
 		}).Return(nil)
 
-		client := rfservice.NewRedisFailoverKubeClient(ms, log.Dummy, metrics.Dummy)
+		client := rfservice.NewRedisFailoverKubeClient(ms, log.Dummy, metrics.Dummy, "2")
 		err := client.EnsureRedisStatefulset(rf, nil, []metav1.OwnerReference{})
 
 		assert.NoError(err)
@@ -2033,7 +2033,7 @@ func TestSentinelCustomLivenessProbe(t *testing.T) {
 			livenessProbe = d.Spec.Template.Spec.Containers[0].LivenessProbe
 		}).Return(nil)
 
-		client := rfservice.NewRedisFailoverKubeClient(ms, log.Dummy, metrics.Dummy)
+		client := rfservice.NewRedisFailoverKubeClient(ms, log.Dummy, metrics.Dummy, "2")
 		err := client.EnsureSentinelDeployment(rf, nil, []metav1.OwnerReference{})
 
 		assert.NoError(err)
@@ -2100,7 +2100,7 @@ func TestRedisCustomReadinessProbe(t *testing.T) {
 			readinessProbe = s.Spec.Template.Spec.Containers[0].ReadinessProbe
 		}).Return(nil)
 
-		client := rfservice.NewRedisFailoverKubeClient(ms, log.Dummy, metrics.Dummy)
+		client := rfservice.NewRedisFailoverKubeClient(ms, log.Dummy, metrics.Dummy, "2")
 		err := client.EnsureRedisStatefulset(rf, nil, []metav1.OwnerReference{})
 
 		assert.NoError(err)
@@ -2179,7 +2179,7 @@ func TestSentinelCustomReadinessProbe(t *testing.T) {
 			readinessProbe = d.Spec.Template.Spec.Containers[0].ReadinessProbe
 		}).Return(nil)
 
-		client := rfservice.NewRedisFailoverKubeClient(ms, log.Dummy, metrics.Dummy)
+		client := rfservice.NewRedisFailoverKubeClient(ms, log.Dummy, metrics.Dummy, "2")
 		err := client.EnsureSentinelDeployment(rf, nil, []metav1.OwnerReference{})
 
 		assert.NoError(err)
@@ -2238,7 +2238,7 @@ func TestRedisCustomStartupProbe(t *testing.T) {
 			startupProbe = s.Spec.Template.Spec.Containers[0].StartupProbe
 		}).Return(nil)
 
-		client := rfservice.NewRedisFailoverKubeClient(ms, log.Dummy, metrics.Dummy)
+		client := rfservice.NewRedisFailoverKubeClient(ms, log.Dummy, metrics.Dummy, "2")
 		err := client.EnsureRedisStatefulset(rf, nil, []metav1.OwnerReference{})
 
 		assert.NoError(err)
@@ -2305,7 +2305,7 @@ func TestSentinelCustomStartupProbe(t *testing.T) {
 			startupProbe = d.Spec.Template.Spec.Containers[0].StartupProbe
 		}).Return(nil)
 
-		client := rfservice.NewRedisFailoverKubeClient(ms, log.Dummy, metrics.Dummy)
+		client := rfservice.NewRedisFailoverKubeClient(ms, log.Dummy, metrics.Dummy, "2")
 		err := client.EnsureSentinelDeployment(rf, nil, []metav1.OwnerReference{})
 
 		assert.NoError(err)


### PR DESCRIPTION
Fixes # .

Changes proposed on the PR:
- add the argument `pdb-minAvailable` to change the  default pdb min available value