### PR TITLE
add namespace to all resources

### DIFF
--- a/charts/redisoperator/Chart.yaml
+++ b/charts/redisoperator/Chart.yaml
@@ -4,7 +4,7 @@ appVersion: 1.2.4
 apiVersion: v1
 description: A Helm chart for the Spotahome Redis Operator
 name: redis-operator
-version: 3.2.8
+version: 3.2.9
 home: https://github.com/spotahome/redis-operator
 keywords:
   - "golang"

--- a/charts/redisoperator/templates/_helpers.tpl
+++ b/charts/redisoperator/templates/_helpers.tpl
@@ -76,3 +76,10 @@ Create the name of the service account to use
 {{- printf "{\"auths\":{\"%s\":{\"username\":\"%s\",\"password\":\"%s\",\"email\":\"%s\",\"auth\":\"%s\"}}}" .registry .username .password .email (printf "%s:%s" .username .password | b64enc) | b64enc }}
 {{- end }}
 {{- end }}
+
+{{/*
+Create the name of the namespace
+*/}}
+{{- define "chart.namespaceName" -}}
+{{- default .Release.Namespace .Values.namespace }}
+{{- end }}

--- a/charts/redisoperator/templates/deployment.yaml
+++ b/charts/redisoperator/templates/deployment.yaml
@@ -5,6 +5,7 @@ apiVersion: {{ template "common.capabilities.deployment.apiVersion" . }}
 kind: Deployment
 metadata:
   name: {{ $fullName }}
+  namespace: {{ include "chart.namespaceName" . }}
   labels:
     {{- include "chart.labels" $data | nindent 4 }}
   {{- if .Values.annotations }}

--- a/charts/redisoperator/templates/monitoring.yaml
+++ b/charts/redisoperator/templates/monitoring.yaml
@@ -6,6 +6,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ $fullName }}-prometheus
+  namespace: {{ include "chart.namespaceName" . }}
   labels:
     prometheus: {{ .Values.monitoring.prometheus.name }}
     {{- include "chart.labels" $data | nindent 4 }}
@@ -28,6 +29,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ $fullName }}
+  namespace: {{ include "chart.namespaceName" . }}
   labels:
     prometheus: {{ .Values.monitoring.prometheus.name }}
     {{- include "chart.labels" $data | nindent 4 }}
@@ -38,7 +40,7 @@ spec:
      {{- include "chart.selectorLabels" $data | nindent 6 }}
   namespaceSelector:
     matchNames:
-    - {{ .Release.Namespace }}
+    - {{ include "chart.namespaceName" . }}
   endpoints:
   - port: metrics
     interval: 15s

--- a/charts/redisoperator/templates/private-registry.yaml
+++ b/charts/redisoperator/templates/private-registry.yaml
@@ -6,6 +6,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ $fullName }}-{{ $name }}
+  namespace: {{ include "chart.namespaceName" . }}
   labels:
     {{- include "chart.labels" $data | nindent 4 }}
   {{- if .Values.annotations }}

--- a/charts/redisoperator/templates/service-account.yaml
+++ b/charts/redisoperator/templates/service-account.yaml
@@ -5,6 +5,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ $fullName }}
+  namespace: {{ include "chart.namespaceName" . }}
   labels:
     {{- include "chart.labels" $data | nindent 4 }}
 ---
@@ -106,7 +107,7 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: {{ $fullName }}
-    namespace: {{ .Release.Namespace }}
+    namespace: {{ include "chart.namespaceName" . }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/charts/redisoperator/templates/service.yaml
+++ b/charts/redisoperator/templates/service.yaml
@@ -5,6 +5,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ $fullName }}
+  namespace: {{ include "chart.namespaceName" . }}
   labels:
     {{- include "chart.labels" $data | nindent 4 }}
   {{- if .Values.annotations }}

--- a/charts/redisoperator/values.yaml
+++ b/charts/redisoperator/values.yaml
@@ -29,6 +29,10 @@ nameOverride: ""
 # A name to substitute for the full names of resources.
 fullnameOverride: ""
 
+# The name of the Namespace to deploy
+# If not set, `.Release.Namespace` is used
+namespace: null
+
 serviceAccount:
   # Enable service account creation.
   create: true


### PR DESCRIPTION
Fixes # .

Changes proposed on the PR:
- Add `namespace` in all Helm chart resources. This doesn't cause any major changes, it just allows `helm template` to also template with namespace. The absence of which can cause some test tools, for example, kyverno-cli to fail due to missing namespace, which is a part of its best practice policies. This namespace adding structure was inspired from how promtail does it.
