### PR TITLE
updating underlying image from golang golang:1.19-alpine to golang:1.…

### DIFF
--- a/docker/app/Dockerfile
+++ b/docker/app/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM golang:1.19-alpine AS build
+FROM --platform=$BUILDPLATFORM golang:1.20-alpine AS build
 RUN apk --no-cache add \
   bash
 

--- a/docker/development/Dockerfile
+++ b/docker/development/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.19-alpine
+FROM golang:1.20-alpine
 
 ENV CODEGEN_VERSION="1.11.9"
 


### PR DESCRIPTION
…20-alpine

Fixes #609

Changes proposed on the PR: updating the base image to allow patching of CVE-2022-41723 and just updates in general to make a new image
- 
- 
- 