### PR TITLE
Add cli args to deployment nand helm values

### DIFF
--- a/charts/redisoperator/templates/deployment.yaml
+++ b/charts/redisoperator/templates/deployment.yaml
@@ -40,6 +40,10 @@ spec:
       containers:
       - name: {{ .Chart.Name }}
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion}}"
+        {{- if .Values.image.cli_args }}
+        args: 
+        - {{ quote .Values.image.cli_args }}
+        {{- end }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         ports:
           - name: metrics

--- a/charts/redisoperator/values.yaml
+++ b/charts/redisoperator/values.yaml
@@ -7,6 +7,7 @@ image:
   repository: quay.io/spotahome/redis-operator
   pullPolicy: IfNotPresent
   tag: v1.2.4
+  cli_args: ""
 
 imageCredentials:
   create: false


### PR DESCRIPTION
Fixes #619 

Changes proposed on the PR:
- Adds the helm value "image.cli_args"
- Sets `args` of the operator container in the chart's templates