### PR TITLE
Expect surge in running pods and avoid redis public expose

### DIFF
--- a/operator/redisfailover/service/check.go
+++ b/operator/redisfailover/service/check.go
@@ -12,6 +12,7 @@ import (
 	redisfailoverv1 "github.com/spotahome/redis-operator/api/redisfailover/v1"
 	"github.com/spotahome/redis-operator/log"
 	"github.com/spotahome/redis-operator/metrics"
+	"github.com/spotahome/redis-operator/operator/redisfailover/util"
 	"github.com/spotahome/redis-operator/service/k8s"
 	"github.com/spotahome/redis-operator/service/redis"
 )
@@ -498,10 +499,13 @@ func getRedisPort(p int32) string {
 func AreAllRunning(pods *corev1.PodList, expectedRunningPods int) bool {
 	var runningPods int
 	for _, pod := range pods.Items {
-		if pod.Status.Phase != corev1.PodRunning || pod.DeletionTimestamp != nil {
+		if util.PodIsScheduling(&pod) {
+			return false
+		}
+		if util.PodIsTerminal(&pod) {
 			continue
 		}
 		runningPods++
 	}
-	return runningPods == expectedRunningPods
+	return runningPods >= expectedRunningPods
 }

--- a/operator/redisfailover/service/generator.go
+++ b/operator/redisfailover/service/generator.go
@@ -130,8 +130,7 @@ func generateRedisMasterService(rf *redisfailoverv1.RedisFailover, labels map[st
 			Annotations:     rf.Spec.Redis.ServiceAnnotations,
 		},
 		Spec: corev1.ServiceSpec{
-			Type:      corev1.ServiceTypeClusterIP,
-			ClusterIP: corev1.ClusterIPNone,
+			Type: corev1.ServiceTypeClusterIP,
 			Ports: []corev1.ServicePort{
 				{
 					Name:       "redis",
@@ -164,8 +163,7 @@ func generateRedisSlaveService(rf *redisfailoverv1.RedisFailover, labels map[str
 			Annotations:     rf.Spec.Redis.ServiceAnnotations,
 		},
 		Spec: corev1.ServiceSpec{
-			Type:      corev1.ServiceTypeClusterIP,
-			ClusterIP: corev1.ClusterIPNone,
+			Type: corev1.ServiceTypeClusterIP,
 			Ports: []corev1.ServicePort{
 				{
 					Name:       "redis",

--- a/operator/redisfailover/service/generator.go
+++ b/operator/redisfailover/service/generator.go
@@ -130,7 +130,8 @@ func generateRedisMasterService(rf *redisfailoverv1.RedisFailover, labels map[st
 			Annotations:     rf.Spec.Redis.ServiceAnnotations,
 		},
 		Spec: corev1.ServiceSpec{
-			Type: corev1.ServiceTypeLoadBalancer,
+			Type:      corev1.ServiceTypeClusterIP,
+			ClusterIP: corev1.ClusterIPNone,
 			Ports: []corev1.ServicePort{
 				{
 					Name:       "redis",
@@ -163,7 +164,8 @@ func generateRedisSlaveService(rf *redisfailoverv1.RedisFailover, labels map[str
 			Annotations:     rf.Spec.Redis.ServiceAnnotations,
 		},
 		Spec: corev1.ServiceSpec{
-			Type: corev1.ServiceTypeLoadBalancer,
+			Type:      corev1.ServiceTypeClusterIP,
+			ClusterIP: corev1.ClusterIPNone,
 			Ports: []corev1.ServicePort{
 				{
 					Name:       "redis",

--- a/operator/redisfailover/service/generator_test.go
+++ b/operator/redisfailover/service/generator_test.go
@@ -1322,7 +1322,8 @@ func TestRedisMasterService(t *testing.T) {
 					},
 				},
 				Spec: corev1.ServiceSpec{
-					Type: corev1.ServiceTypeLoadBalancer,
+					Type:      corev1.ServiceTypeClusterIP,
+					ClusterIP: "None",
 					Selector: map[string]string{
 						"app.kubernetes.io/component": "redis",
 						"app.kubernetes.io/name":      name,
@@ -1361,7 +1362,8 @@ func TestRedisMasterService(t *testing.T) {
 					},
 				},
 				Spec: corev1.ServiceSpec{
-					Type: corev1.ServiceTypeLoadBalancer,
+					Type:      corev1.ServiceTypeClusterIP,
+					ClusterIP: "None",
 					Selector: map[string]string{
 						"app.kubernetes.io/component": "redis",
 						"app.kubernetes.io/name":      "custom-name",
@@ -1400,7 +1402,8 @@ func TestRedisMasterService(t *testing.T) {
 					},
 				},
 				Spec: corev1.ServiceSpec{
-					Type: corev1.ServiceTypeLoadBalancer,
+					Type:      corev1.ServiceTypeClusterIP,
+					ClusterIP: "None",
 					Selector: map[string]string{
 						"app.kubernetes.io/component": "redis",
 						"app.kubernetes.io/name":      name,
@@ -1440,7 +1443,8 @@ func TestRedisMasterService(t *testing.T) {
 					},
 				},
 				Spec: corev1.ServiceSpec{
-					Type: corev1.ServiceTypeLoadBalancer,
+					Type:      corev1.ServiceTypeClusterIP,
+					ClusterIP: "None",
 					Selector: map[string]string{
 						"app.kubernetes.io/component": "redis",
 						"app.kubernetes.io/name":      name,
@@ -1481,7 +1485,8 @@ func TestRedisMasterService(t *testing.T) {
 					},
 				},
 				Spec: corev1.ServiceSpec{
-					Type: corev1.ServiceTypeLoadBalancer,
+					Type:      corev1.ServiceTypeClusterIP,
+					ClusterIP: "None",
 					Selector: map[string]string{
 						"app.kubernetes.io/component": "redis",
 						"app.kubernetes.io/name":      name,
@@ -1562,7 +1567,8 @@ func TestRedisSlaveService(t *testing.T) {
 					},
 				},
 				Spec: corev1.ServiceSpec{
-					Type: corev1.ServiceTypeLoadBalancer,
+					Type:      corev1.ServiceTypeClusterIP,
+					ClusterIP: "None",
 					Selector: map[string]string{
 						"app.kubernetes.io/component": "redis",
 						"app.kubernetes.io/name":      name,
@@ -1601,7 +1607,8 @@ func TestRedisSlaveService(t *testing.T) {
 					},
 				},
 				Spec: corev1.ServiceSpec{
-					Type: corev1.ServiceTypeLoadBalancer,
+					Type:      corev1.ServiceTypeClusterIP,
+					ClusterIP: "None",
 					Selector: map[string]string{
 						"app.kubernetes.io/component": "redis",
 						"app.kubernetes.io/name":      "custom-name",
@@ -1640,7 +1647,8 @@ func TestRedisSlaveService(t *testing.T) {
 					},
 				},
 				Spec: corev1.ServiceSpec{
-					Type: corev1.ServiceTypeLoadBalancer,
+					Type:      corev1.ServiceTypeClusterIP,
+					ClusterIP: "None",
 					Selector: map[string]string{
 						"app.kubernetes.io/component": "redis",
 						"app.kubernetes.io/name":      name,
@@ -1680,7 +1688,8 @@ func TestRedisSlaveService(t *testing.T) {
 					},
 				},
 				Spec: corev1.ServiceSpec{
-					Type: corev1.ServiceTypeLoadBalancer,
+					Type:      corev1.ServiceTypeClusterIP,
+					ClusterIP: "None",
 					Selector: map[string]string{
 						"app.kubernetes.io/component": "redis",
 						"app.kubernetes.io/name":      name,
@@ -1721,7 +1730,8 @@ func TestRedisSlaveService(t *testing.T) {
 					},
 				},
 				Spec: corev1.ServiceSpec{
-					Type: corev1.ServiceTypeLoadBalancer,
+					Type:      corev1.ServiceTypeClusterIP,
+					ClusterIP: "None",
 					Selector: map[string]string{
 						"app.kubernetes.io/component": "redis",
 						"app.kubernetes.io/name":      name,

--- a/operator/redisfailover/service/generator_test.go
+++ b/operator/redisfailover/service/generator_test.go
@@ -1322,8 +1322,7 @@ func TestRedisMasterService(t *testing.T) {
 					},
 				},
 				Spec: corev1.ServiceSpec{
-					Type:      corev1.ServiceTypeClusterIP,
-					ClusterIP: "None",
+					Type: corev1.ServiceTypeClusterIP,
 					Selector: map[string]string{
 						"app.kubernetes.io/component": "redis",
 						"app.kubernetes.io/name":      name,
@@ -1362,8 +1361,7 @@ func TestRedisMasterService(t *testing.T) {
 					},
 				},
 				Spec: corev1.ServiceSpec{
-					Type:      corev1.ServiceTypeClusterIP,
-					ClusterIP: "None",
+					Type: corev1.ServiceTypeClusterIP,
 					Selector: map[string]string{
 						"app.kubernetes.io/component": "redis",
 						"app.kubernetes.io/name":      "custom-name",
@@ -1402,8 +1400,7 @@ func TestRedisMasterService(t *testing.T) {
 					},
 				},
 				Spec: corev1.ServiceSpec{
-					Type:      corev1.ServiceTypeClusterIP,
-					ClusterIP: "None",
+					Type: corev1.ServiceTypeClusterIP,
 					Selector: map[string]string{
 						"app.kubernetes.io/component": "redis",
 						"app.kubernetes.io/name":      name,
@@ -1443,8 +1440,7 @@ func TestRedisMasterService(t *testing.T) {
 					},
 				},
 				Spec: corev1.ServiceSpec{
-					Type:      corev1.ServiceTypeClusterIP,
-					ClusterIP: "None",
+					Type: corev1.ServiceTypeClusterIP,
 					Selector: map[string]string{
 						"app.kubernetes.io/component": "redis",
 						"app.kubernetes.io/name":      name,
@@ -1485,8 +1481,7 @@ func TestRedisMasterService(t *testing.T) {
 					},
 				},
 				Spec: corev1.ServiceSpec{
-					Type:      corev1.ServiceTypeClusterIP,
-					ClusterIP: "None",
+					Type: corev1.ServiceTypeClusterIP,
 					Selector: map[string]string{
 						"app.kubernetes.io/component": "redis",
 						"app.kubernetes.io/name":      name,
@@ -1567,8 +1562,7 @@ func TestRedisSlaveService(t *testing.T) {
 					},
 				},
 				Spec: corev1.ServiceSpec{
-					Type:      corev1.ServiceTypeClusterIP,
-					ClusterIP: "None",
+					Type: corev1.ServiceTypeClusterIP,
 					Selector: map[string]string{
 						"app.kubernetes.io/component": "redis",
 						"app.kubernetes.io/name":      name,
@@ -1607,8 +1601,7 @@ func TestRedisSlaveService(t *testing.T) {
 					},
 				},
 				Spec: corev1.ServiceSpec{
-					Type:      corev1.ServiceTypeClusterIP,
-					ClusterIP: "None",
+					Type: corev1.ServiceTypeClusterIP,
 					Selector: map[string]string{
 						"app.kubernetes.io/component": "redis",
 						"app.kubernetes.io/name":      "custom-name",
@@ -1647,8 +1640,7 @@ func TestRedisSlaveService(t *testing.T) {
 					},
 				},
 				Spec: corev1.ServiceSpec{
-					Type:      corev1.ServiceTypeClusterIP,
-					ClusterIP: "None",
+					Type: corev1.ServiceTypeClusterIP,
 					Selector: map[string]string{
 						"app.kubernetes.io/component": "redis",
 						"app.kubernetes.io/name":      name,
@@ -1688,8 +1680,7 @@ func TestRedisSlaveService(t *testing.T) {
 					},
 				},
 				Spec: corev1.ServiceSpec{
-					Type:      corev1.ServiceTypeClusterIP,
-					ClusterIP: "None",
+					Type: corev1.ServiceTypeClusterIP,
 					Selector: map[string]string{
 						"app.kubernetes.io/component": "redis",
 						"app.kubernetes.io/name":      name,
@@ -1730,8 +1721,7 @@ func TestRedisSlaveService(t *testing.T) {
 					},
 				},
 				Spec: corev1.ServiceSpec{
-					Type:      corev1.ServiceTypeClusterIP,
-					ClusterIP: "None",
+					Type: corev1.ServiceTypeClusterIP,
 					Selector: map[string]string{
 						"app.kubernetes.io/component": "redis",
 						"app.kubernetes.io/name":      name,

--- a/operator/redisfailover/util/pod.go
+++ b/operator/redisfailover/util/pod.go
@@ -1,0 +1,11 @@
+package util
+
+import v1 "k8s.io/api/core/v1"
+
+func PodIsTerminal(pod *v1.Pod) bool {
+	return pod.Status.Phase == v1.PodFailed || pod.Status.Phase == v1.PodSucceeded
+}
+
+func PodIsScheduling(pod *v1.Pod) bool {
+	return pod.DeletionTimestamp != nil || pod.Status.Phase == v1.PodPending
+}


### PR DESCRIPTION
Service to access directly master and slaves instances in Redis was added in #627, This exposes the service publicly using loadBalancers.
To make it security by default the service is changed to only expose internally in the cluster. Let the user to create their ow service if exposing publicly is the option until its available in the operator by a config set.

Running pods can surge the number of expected replicas during rollouts of a deployment change in sentinels, while a new version of the template is deployed. In anycase we will always consider not running while there are pods terminating or pending .