### PR TITLE
Tune exporter container cpu

### DIFF
--- a/operator/redisfailover/service/constants.go
+++ b/operator/redisfailover/service/constants.go
@@ -7,8 +7,8 @@ const (
 	exporterPortName              = "http-metrics"
 	exporterContainerName         = "redis-exporter"
 	sentinelExporterContainerName = "sentinel-exporter"
-	exporterDefaultRequestCPU     = "25m"
-	exporterDefaultLimitCPU       = "50m"
+	exporterDefaultRequestCPU     = "10m"
+	exporterDefaultLimitCPU       = "1000m"
 	exporterDefaultRequestMemory  = "50Mi"
 	exporterDefaultLimitMemory    = "100Mi"
 )


### PR DESCRIPTION
Fix CPU throttling for redis exporter container:

<img width="1427" alt="Capture d’écran, le 2023-08-18 à 12 30 16" src="https://github.com/spotahome/redis-operator/assets/1219817/681fa6a8-4a8e-4a4b-8275-d8ffef0d90c1">

Also set request to 10m, which is far enough. 