### PR TITLE
Fix go template annotations of CRD in the helm chart

### DIFF
--- a/charts/redisoperator/Chart.yaml
+++ b/charts/redisoperator/Chart.yaml
@@ -4,7 +4,7 @@ appVersion: 1.3.0
 apiVersion: v1
 description: A Helm chart for the Spotahome Redis Operator
 name: redis-operator
-version: 3.3.0
+version: 3.3.1
 home: https://github.com/spotahome/redis-operator
 keywords:
   - "golang"

--- a/charts/redisoperator/crds/databases.spotahome.com_redisfailovers.yaml
+++ b/charts/redisoperator/crds/databases.spotahome.com_redisfailovers.yaml
@@ -4,9 +4,6 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    {{- with .Values.crds.annotations }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
     controller-gen.kubebuilder.io/version: (devel)
   creationTimestamp: null
   name: redisfailovers.databases.spotahome.com

--- a/charts/redisoperator/values.yaml
+++ b/charts/redisoperator/values.yaml
@@ -87,12 +87,4 @@ tolerations: []
 
 affinity: {}
 
-# CRDs configuration
-crds:
-  # -- Additional CRDs annotations
-  annotations: {}
-    # argocd.argoproj.io/sync-options: Replace=true
-    # strategy.spinnaker.io/replace: 'true'
-
 priorityClassName: ""
-


### PR DESCRIPTION
Fixes https://github.com/spotahome/redis-operator/issues/654.

I saw that a current PR is open with the same changed (https://github.com/spotahome/redis-operator/pull/651), but it could be great to make this fix first without another change.

Changes proposed on the PR:
- fix go template annotations in the crd 