### PR TITLE
enable override defaults for redis images

### DIFF
--- a/api/redisfailover/v1/defaults.go
+++ b/api/redisfailover/v1/defaults.go
@@ -1,12 +1,9 @@
 package v1
 
 const (
-	defaultRedisNumber           = 3
-	defaultSentinelNumber        = 3
-	defaultSentinelExporterImage = "quay.io/oliver006/redis_exporter:v1.43.0"
-	defaultExporterImage         = "quay.io/oliver006/redis_exporter:v1.43.0"
-	defaultImage                 = "redis:6.2.6-alpine"
-	defaultRedisPort             = 6379
+	defaultRedisNumber    = 3
+	defaultSentinelNumber = 3
+	defaultRedisPort      = 6379
 )
 
 var (
@@ -20,4 +17,7 @@ var (
 	bootstrappingRedisCustomConfig = []string{
 		"replica-priority 0",
 	}
+	DefaultSentinelExporterImage = "quay.io/oliver006/redis_exporter:v1.43.0"
+	DefaultExporterImage         = "quay.io/oliver006/redis_exporter:v1.43.0"
+	DefaultImage                 = "redis:6.2.6-alpine"
 )

--- a/api/redisfailover/v1/validate.go
+++ b/api/redisfailover/v1/validate.go
@@ -30,11 +30,11 @@ func (r *RedisFailover) Validate() error {
 	}
 
 	if r.Spec.Redis.Image == "" {
-		r.Spec.Redis.Image = defaultImage
+		r.Spec.Redis.Image = DefaultImage
 	}
 
 	if r.Spec.Sentinel.Image == "" {
-		r.Spec.Sentinel.Image = defaultImage
+		r.Spec.Sentinel.Image = DefaultImage
 	}
 
 	if r.Spec.Redis.Replicas <= 0 {
@@ -50,11 +50,11 @@ func (r *RedisFailover) Validate() error {
 	}
 
 	if r.Spec.Redis.Exporter.Image == "" {
-		r.Spec.Redis.Exporter.Image = defaultExporterImage
+		r.Spec.Redis.Exporter.Image = DefaultExporterImage
 	}
 
 	if r.Spec.Sentinel.Exporter.Image == "" {
-		r.Spec.Sentinel.Exporter.Image = defaultSentinelExporterImage
+		r.Spec.Sentinel.Exporter.Image = DefaultSentinelExporterImage
 	}
 
 	if len(r.Spec.Sentinel.CustomConfig) == 0 {

--- a/api/redisfailover/v1/validate_test.go
+++ b/api/redisfailover/v1/validate_test.go
@@ -102,20 +102,20 @@ func TestValidate(t *testing.T) {
 					},
 					Spec: RedisFailoverSpec{
 						Redis: RedisSettings{
-							Image:    defaultImage,
+							Image:    DefaultImage,
 							Replicas: defaultRedisNumber,
 							Port:     defaultRedisPort,
 							Exporter: Exporter{
-								Image: defaultExporterImage,
+								Image: DefaultExporterImage,
 							},
 							CustomConfig: expectedRedisCustomConfig,
 						},
 						Sentinel: SentinelSettings{
-							Image:        defaultImage,
+							Image:        DefaultImage,
 							Replicas:     defaultSentinelNumber,
 							CustomConfig: expectedSentinelCustomConfig,
 							Exporter: Exporter{
-								Image: defaultSentinelExporterImage,
+								Image: DefaultSentinelExporterImage,
 							},
 						},
 						BootstrapNode: test.expectedBootstrapNode,

--- a/cmd/redisoperator/main.go
+++ b/cmd/redisoperator/main.go
@@ -87,6 +87,9 @@ func (m *Main) Run() error {
 	// Get lease lock resource namespace
 	lockNamespace := getNamespace()
 
+	// Override default values  provided by flags
+	m.flags.ReinitiliazeDefaults()
+
 	// Create operator and run.
 	redisfailoverOperator, err := redisfailover.New(m.flags.ToRedisOperatorConfig(), k8sservice, k8sClient, lockNamespace, redisClient, metricsRecorder, m.logger)
 	if err != nil {

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -3,6 +3,7 @@ package utils
 import (
 	"flag"
 	"fmt"
+	v1 "github.com/spotahome/redis-operator/api/redisfailover/v1"
 	"path/filepath"
 	"regexp"
 
@@ -13,15 +14,18 @@ import (
 // CMDFlags are the flags used by the cmd
 // TODO: improve flags.
 type CMDFlags struct {
-	KubeConfig               string
-	SupportedNamespacesRegex string
-	Development              bool
-	ListenAddr               string
-	MetricsPath              string
-	K8sQueriesPerSecond      int
-	K8sQueriesBurstable      int
-	Concurrency              int
-	LogLevel                 string
+	KubeConfig                   string
+	SupportedNamespacesRegex     string
+	Development                  bool
+	ListenAddr                   string
+	MetricsPath                  string
+	K8sQueriesPerSecond          int
+	K8sQueriesBurstable          int
+	Concurrency                  int
+	LogLevel                     string
+	DefaultRedisImage            string
+	DefaultRedisExporterImage    string
+	DefaultSentinelExporterImage string
 }
 
 // Init initializes and parse the flags
@@ -39,6 +43,9 @@ func (c *CMDFlags) Init() {
 	// reference: https://github.com/spotahome/kooper/blob/master/controller/controller.go#L89
 	flag.IntVar(&c.Concurrency, "concurrency", 3, "Number of conccurent workers meant to process events")
 	flag.StringVar(&c.LogLevel, "log-level", "info", "set log level")
+	flag.StringVar(&c.DefaultRedisImage, "redis-default-image", v1.DefaultImage, "default redis image")
+	flag.StringVar(&c.DefaultRedisExporterImage, "rfr-exporter-default-image", v1.DefaultExporterImage, "default redis exporter image")
+	flag.StringVar(&c.DefaultSentinelExporterImage, "rfs-exporter-default-image", v1.DefaultSentinelExporterImage, "default sentinel exporter image")
 	// Parse flags
 	flag.Parse()
 
@@ -55,4 +62,11 @@ func (c *CMDFlags) ToRedisOperatorConfig() redisfailover.Config {
 		Concurrency:              c.Concurrency,
 		SupportedNamespacesRegex: c.SupportedNamespacesRegex,
 	}
+}
+
+// ReinitiliazeDefaults redefine default values overridden by flags
+func (c *CMDFlags) ReinitiliazeDefaults() {
+	v1.DefaultImage = c.DefaultRedisImage
+	v1.DefaultExporterImage = c.DefaultRedisExporterImage
+	v1.DefaultSentinelExporterImage = c.DefaultSentinelExporterImage
 }

--- a/example/operator/custom-redisfailover-image-defaults.yaml
+++ b/example/operator/custom-redisfailover-image-defaults.yaml
@@ -1,0 +1,45 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: redisoperator
+  name: redisoperator
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: redisoperator
+  strategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app: redisoperator
+    spec:
+      serviceAccountName: redisoperator
+      containers:
+        - image: quay.io/spotahome/redis-operator:latest
+          args:
+            - -redis-default-image=redis:6.2.4-alpine
+            - -rfr-exporter-default-image=quay.io/oliver006/redis_exporter:v1.50.0
+            - -rfs-exporter-default-image=quay.io/oliver006/redis_exporter:v1.50.0
+          imagePullPolicy: IfNotPresent
+          name: app
+          securityContext:
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1000
+          resources:
+            limits:
+              cpu: 100m
+              memory: 50Mi
+            requests:
+              cpu: 10m
+              memory: 50Mi
+          env:
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+      restartPolicy: Always

--- a/operator/redisfailover/config.go
+++ b/operator/redisfailover/config.go
@@ -2,8 +2,11 @@ package redisfailover
 
 // Config is the configuration for the redis operator.
 type Config struct {
-	ListenAddress            string
-	MetricsPath              string
-	Concurrency              int
-	SupportedNamespacesRegex string
+	ListenAddress                string
+	MetricsPath                  string
+	Concurrency                  int
+	SupportedNamespacesRegex     string
+	DefaultImage                 string
+	DefaultExporterImage         string
+	DefaultSentinelExporterImage string
 }


### PR DESCRIPTION
Current implementation

since default Redis images are hardcoded, updating redis-operator version might cause all incances of redisdailover cluster are restarted if hardcoded default values has changed. It might be undesirable behavior especially in production environment (assume deploy with gitops argocd)

<br/><br/>

Propose implementation

default images  are externally configurable. You can change redis-operator version but your defined default versions of redisfailover instances stay still -> redisfailover instances not change  -> no restart