### PR TITLE
Modernize patch syntax in kustomizations

### DIFF
--- a/manifests/kustomize/components/monitoring/kustomization.yaml
+++ b/manifests/kustomize/components/monitoring/kustomization.yaml
@@ -5,8 +5,8 @@ resources:
   - service.yaml
   - servicemonitor.yaml
 
-patchesStrategicMerge:
-  - deployment.yaml
+patches:
+  - path: deployment.yaml
 
 configurations:
   - kustomizeconfig.yaml

--- a/manifests/kustomize/components/rbac-full/kustomization.yaml
+++ b/manifests/kustomize/components/rbac-full/kustomization.yaml
@@ -8,5 +8,5 @@ resources:
   - clusterrolebinding.yaml
   - serviceaccount.yaml
 
-patchesStrategicMerge:
-  - deployment.yaml
+patches:
+  - path: deployment.yaml

--- a/manifests/kustomize/components/resources/kustomization.yaml
+++ b/manifests/kustomize/components/resources/kustomization.yaml
@@ -1,5 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1alpha1
 kind: Component
 
-patchesStrategicMerge:
-  - deployment.yaml
+patches:
+  - path: deployment.yaml


### PR DESCRIPTION
The `patchesStrategicMerge` keyword has been deprecated in Kustomize for
quite some time, and generates warnings with recent versions of Kustomize:

    Warning: 'patchesStrategicMerge' is deprecated. Please use 'patches'
    instead. Run 'kustomize edit fix' to update your Kustomization
    automatically.

This commit replaces all instances of:

    patchesStrategicMerge:
    - somepatch.yaml

With:

    patches:
    - path: somepatch.yaml
