### PR TITLE
chore(chart): add topologySpreadConstraints

### DIFF
--- a/charts/redisoperator/Chart.yaml
+++ b/charts/redisoperator/Chart.yaml
@@ -4,7 +4,7 @@ appVersion: 1.3.0
 apiVersion: v1
 description: A Helm chart for the Spotahome Redis Operator
 name: redis-operator
-version: 3.3.0
+version: 3.3.1
 home: https://github.com/spotahome/redis-operator
 keywords:
   - "golang"

--- a/charts/redisoperator/templates/deployment.yaml
+++ b/charts/redisoperator/templates/deployment.yaml
@@ -80,6 +80,10 @@ spec:
       nodeSelector:
         {{- toYaml . | nindent 8 }}
     {{- end }}
+    {{- with .Values.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
     {{- if .Values.priorityClassName }}
       priorityClassName: {{ .Values.priorityClassName }}
     {{- end }}

--- a/charts/redisoperator/values.yaml
+++ b/charts/redisoperator/values.yaml
@@ -87,6 +87,8 @@ tolerations: []
 
 affinity: {}
 
+topologySpreadConstraints: []
+
 # CRDs configuration
 crds:
   # -- Additional CRDs annotations


### PR DESCRIPTION
Changes proposed on the PR:
- add topologySpreadConstraints to the Helm chart

It's currently not possible to define topologySpreadConstraints when deploying the operator. It could be useful to spread the deployment across different nodes/zones.

Thanks in advance for reviewing.