### PR TITLE
add port metrics to deployment in examples

### DIFF
--- a/example/operator/all-redis-operator-resources.yaml
+++ b/example/operator/all-redis-operator-resources.yaml
@@ -21,6 +21,10 @@ spec:
         - image: quay.io/spotahome/redis-operator:latest
           imagePullPolicy: IfNotPresent
           name: app
+          ports:
+          - containerPort: 9710
+            name: metrics
+            protocol: TCP
           securityContext:
             readOnlyRootFilesystem: true
             runAsNonRoot: true
@@ -102,7 +106,7 @@ rules:
       - leases
     verbs:
       - "*"
-      
+
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -126,7 +130,6 @@ spec:
   - name: metrics
     port: 9710
     protocol: TCP
-    targetPort: metrics
   selector:
     app: redisoperator
 ---
@@ -148,7 +151,6 @@ spec:
     matchNames:
     - default
 ---
-
 
 apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor

--- a/example/operator/operator.yaml
+++ b/example/operator/operator.yaml
@@ -21,6 +21,10 @@ spec:
       - image: quay.io/spotahome/redis-operator:latest
         imagePullPolicy: IfNotPresent
         name: app
+        ports:
+        - containerPort: 9710
+          name: metrics
+          protocol: TCP
         securityContext:
           readOnlyRootFilesystem: true
           runAsNonRoot: true


### PR DESCRIPTION
Fixes # .
The small fix adds a port to the deployment in examples because it's one of the ways to install the Redis operator.

Changes proposed on the PR:
- 
- 
- 